### PR TITLE
NuGet Shields

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -21,6 +21,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Update="NGraphics" Version="0.6.0-beta2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/docs/registration.md
+++ b/docs/registration.md
@@ -3,7 +3,7 @@ When setting up a package feed you must call the `AddNuGetPackageApi` extension 
 ```csharp
 public void ConfigureServices(IServiceCollection services)
 {
-    services.AddNuGetPackagApi(app =>
+    services.AddNuGetPackageApi(app =>
     {
         
     });

--- a/docs/shields.md
+++ b/docs/shields.md
@@ -1,0 +1,12 @@
+We commonly many Open Source projects using Shields to provide users an "At a Glance" idea of what the latest package versions are available. This is of course really easy to deal with when our packages are on NuGet.org as we can simply use shields.io to provide us what we need. With a self hosted package feed however it's not as easy. The AvantiPoint Packages feed now includes Shields out of the box in version 3. In order to enable the Shields endpoints simply update your configuration with a Server Name:
+
+```json
+{
+  "Shields": {
+    "ServerName": "AP Packages"
+  }
+}
+```
+
+!!! note
+    If the Shields ServerName is null or empty the Shields endpoint will not be enabled, and will return a 404.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,7 +10,7 @@ repo_url: https://github.com/AvantiPoint/avantipoint.packages
 edit_uri: ""
 
 # Copyright
-copyright: 'Copyright &copy; 2021 AvantiPoint'
+copyright: 'Copyright &copy; 2021-2022 AvantiPoint'
 
 # Configuration
 theme:
@@ -52,4 +52,5 @@ nav:
   - Database: database.md
   - File Storage: storage.md
   - Upstream Mirrors: mirrors.md
+  - Shields: shields.md
   - Templates: templates.md

--- a/samples/OpenFeed/appsettings.json
+++ b/samples/OpenFeed/appsettings.json
@@ -17,8 +17,9 @@
   "IsReadOnlyMode": false,
 
   "Database": {
-    "Type": "MariaDb",
-    "Version": "10.5.9"
+    "Type": "Sqlite"
+    //"Type": "MariaDb",
+    //"Version": "10.5.9"
     //"Type": "SqlServer"
   },
 
@@ -31,6 +32,10 @@
   //  "AccountName": "my-account",
   //  "ApiKey": "ABCD1234"
   //},
+
+  "Shield": {
+   "ServerName": "Open Feed"
+  },
 
   "Storage": {
     "Type": "FileSystem",

--- a/src/AvantiPoint.Packages.Core/Configuration/PackageFeedOptions.cs
+++ b/src/AvantiPoint.Packages.Core/Configuration/PackageFeedOptions.cs
@@ -50,5 +50,7 @@ namespace AvantiPoint.Packages.Core
         public SearchOptions Search { get; set; }
 
         public MirrorOptions Mirror { get; set; }
+
+        public ShieldOptions Shield { get; set; }
     }
 }

--- a/src/AvantiPoint.Packages.Core/Configuration/ShieldOptions.cs
+++ b/src/AvantiPoint.Packages.Core/Configuration/ShieldOptions.cs
@@ -1,0 +1,7 @@
+﻿namespace AvantiPoint.Packages.Core
+{
+    public class ShieldOptions
+    {
+        public string ServerName { get; set; }
+    }
+}

--- a/src/AvantiPoint.Packages.Hosting/Authentication/ShieldConfiguredAttribute.cs
+++ b/src/AvantiPoint.Packages.Hosting/Authentication/ShieldConfiguredAttribute.cs
@@ -1,0 +1,24 @@
+﻿using System.Threading.Tasks;
+using AvantiPoint.Packages.Core;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace AvantiPoint.Packages.Hosting.Authentication
+{
+    internal class ShieldConfiguredAttribute : ActionFilterAttribute
+    {
+        public override async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
+        {
+            var options = context.HttpContext.RequestServices.GetRequiredService<IOptions<PackageFeedOptions>>();
+            if(string.IsNullOrEmpty(options.Value.Shield?.ServerName))
+            {
+                context.HttpContext.Response.StatusCode = 404;
+                await context.HttpContext.Response.CompleteAsync();
+                return;
+            }
+
+            await base.OnActionExecutionAsync(context, next);
+        }
+    }
+}

--- a/src/AvantiPoint.Packages.Hosting/AvantiPoint.Packages.Hosting.csproj
+++ b/src/AvantiPoint.Packages.Hosting/AvantiPoint.Packages.Hosting.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="NGraphics" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AvantiPoint.Packages.Hosting/Controllers/ShieldController.cs
+++ b/src/AvantiPoint.Packages.Hosting/Controllers/ShieldController.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using AvantiPoint.Packages.Core;
+using AvantiPoint.Packages.Hosting.Authentication;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using NGraphics;
+
+namespace AvantiPoint.Packages.Hosting.Controllers
+{
+    [AllowAnonymous]
+    public class ShieldController : ControllerBase
+    {
+        private IContext _context { get; }
+        private PackageFeedOptions _options { get; }
+
+        public ShieldController(IContext context, IOptions<PackageFeedOptions> options)
+        {
+            _context = context;
+            _options = options.Value;
+        }
+
+        [ShieldConfigured]
+        public async Task<IActionResult> GetStable(string packageId)
+        {
+            var packages = await _context.Packages
+                .AsQueryable()
+                .Where(x => x.Id.ToLower() == packageId.ToLower()
+                            && x.IsPrerelease == false)
+                .ToListAsync();
+
+            var package = packages.OrderByDescending(x => x.Version)
+                .FirstOrDefault();
+
+            return Shield(package);
+        }
+
+        [ShieldConfigured]
+        public async Task<IActionResult> GetLatest(string packageId)
+        {
+            var packages = await _context.Packages
+                .AsQueryable()
+                .Where(x => x.Id.ToLower() == packageId.ToLower())
+                .ToListAsync();
+
+            var package = packages.OrderByDescending(x => x.Version)
+                .FirstOrDefault();
+
+            return Shield(package);
+        }
+
+        private IActionResult Shield(Package package)
+        {
+            var content = DrawShield(package);
+            Response.Headers.Add("Cache-Control", "max-age=3600");
+            var result = Content(content);
+            result.ContentType = "image/svg+xml";
+            return result;
+        }
+
+        private string DrawShield(Package package)
+        {
+            var k = _options.Shield.ServerName;
+            var v = package is null ? "Package not found" : $"v{package.Version.OriginalVersion}";
+
+            var font = new Font("DejaVu Sans,Verdana,Geneva,sans-serif", 11);
+            var kw = (int)Math.Round(NullPlatform.GlobalMeasureText(k, font).Width * 1.15);
+            var vw = (int)Math.Round(NullPlatform.GlobalMeasureText(v, font).Width * 1.15);
+
+            var hpad = 8;
+            var w = kw + vw + 4 * hpad;
+            var h = 20;
+            var c = new GraphicCanvas(new Size(w, h));
+
+            var badgeColor = package?.IsPrerelease switch
+            {
+                null => "#FFA500",
+                true => "#BBB90F",
+                false => "#00008B"
+            };
+
+            c.FillRectangle(new Rect(0, 0, w, h), new Size(3, 3), "#555");
+            c.FillRectangle(new Rect(kw + 2 * hpad, 0, w - 2 * hpad - kw, h), new Size(3, 3), badgeColor);
+            c.FillRectangle(new Rect(kw + 2 * hpad, 0, 6, h), badgeColor);
+
+            var scolor = new Color(1.0 / 255.0, 0.3);
+            // c.FillRectangle(new Rect(hpad, 5, kw, font.Size), "#F00");
+            c.DrawText(k, new Point(hpad, 15), font, scolor);
+            c.DrawText(k, new Point(hpad, 14), font, Colors.White);
+
+            // c.FillRectangle(new Rect(w - vw - hpad, 5, vw, font.Size), "#FF0");
+            c.DrawText(v, new Point(w - vw - hpad, 15), font, scolor);
+            c.DrawText(v, new Point(w - vw - hpad, 14), font, Colors.White);
+
+            using var tw = new StringWriter();
+            c.Graphic.WriteSvg(tw);
+            return tw.ToString();
+        }
+    }
+}

--- a/src/AvantiPoint.Packages.Hosting/PackagesApi.cs
+++ b/src/AvantiPoint.Packages.Hosting/PackagesApi.cs
@@ -15,6 +15,7 @@ namespace AvantiPoint.Packages
             MapSearchRoutes(endpoints);
             MapPackageMetadataRoutes(endpoints);
             MapPackageContentRoutes(endpoints);
+            MapShieldRoutes(endpoints);
             return endpoints;
         }
 
@@ -124,6 +125,18 @@ namespace AvantiPoint.Packages
                 name: Routes.PackageDownloadIconRouteName,
                 pattern: "v3/package/{id}/{version}/icon",
                 defaults: new { controller = "PackageContent", action = "DownloadIcon" });
+        }
+
+        public static void MapShieldRoutes(IEndpointRouteBuilder endpoints)
+        {
+            endpoints.MapControllerRoute(
+                name: "shield-stable",
+                pattern: "shield/{packageId}",
+                defaults: new { controller = "Shield", action = "GetStable" });
+            endpoints.MapControllerRoute(
+                name: "shield-latest",
+                pattern: "shield/{packageId}/vpre",
+                defaults: new { controller = "Shield", action = "GetLatest" });
         }
     }
 }

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "3.0-pre",
+  "version": "3.0",
   "assemblyVersion": {
     "precision": "revision"
   },


### PR DESCRIPTION
# Description

Adds support for Shields Endpoint. This will produce an SVG shield like what we see on many open source projects. This requires the ServerName to be configured for the Shields as the Server name is what will appear in the Shield.

- closes #9 