### PR TITLE
chore(deps): update packages and group Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,22 +1,91 @@
 version: 2
 updates:
-- package-ecosystem: nuget
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "13:00"
-  open-pull-requests-limit: 10
-  groups:
-    aws-sdk:
-      applies-to: version-updates
-      patterns:
-        - "AWSSDK.*"
-    nuget:
-      applies-to: version-updates
-      patterns:
-        - "NuGet.*"
-    swashbuckle:
-      applies-to: version-updates
-      patterns:
-        - "Swashbuckle.*"
-
+  - package-ecosystem: nuget
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "13:00"
+    open-pull-requests-limit: 10
+    groups:
+      aspire:
+        applies-to: version-updates
+        patterns:
+          - "Aspire.*"
+          - "CommunityToolkit.Aspire.*"
+      testcontainers:
+        applies-to: version-updates
+        patterns:
+          - "Testcontainers*"
+      azure:
+        applies-to: version-updates
+        patterns:
+          - "Azure.*"
+      microsoft-aspnetcore:
+        applies-to: version-updates
+        patterns:
+          - "Microsoft.AspNetCore.*"
+      microsoft-entityframework:
+        applies-to: version-updates
+        patterns:
+          - "Microsoft.EntityFrameworkCore.*"
+          - "Microsoft.Data.*"
+          - "Npgsql*"
+          - "MySql*"
+      microsoft-extensions:
+        applies-to: version-updates
+        patterns:
+          - "Microsoft.Extensions.*"
+      microsoft-identity:
+        applies-to: version-updates
+        patterns:
+          - "Microsoft.IdentityModel.*"
+          - "System.IdentityModel.*"
+      opentelemetry:
+        applies-to: version-updates
+        patterns:
+          - "OpenTelemetry*"
+      google-cloud:
+        applies-to: version-updates
+        patterns:
+          - "Google.Cloud.*"
+      opensearch:
+        applies-to: version-updates
+        patterns:
+          - "OpenSearch*"
+      system:
+        applies-to: version-updates
+        patterns:
+          - "System.*"
+      xunit:
+        applies-to: version-updates
+        patterns:
+          - "xunit*"
+          - "Microsoft.NET.Test.Sdk"
+          - "Microsoft.Testing.*"
+          - "Moq"
+          - "coverlet*"
+          - "Meziantou.Extensions.Logging.Xunit*"
+          - "GitHubActionsTestLogger"
+          - "bunit"
+      aws-sdk:
+        applies-to: version-updates
+        patterns:
+          - "AWSSDK.*"
+      nuget:
+        applies-to: version-updates
+        patterns:
+          - "NuGet.*"
+      build-tools:
+        applies-to: version-updates
+        patterns:
+          - "Nerdbank.GitVersioning"
+          - "Microsoft.SourceLink.*"
+          - "Microsoft.VisualStudio.*"
+      utilities:
+        applies-to: version-updates
+        patterns:
+          - "FluentFTP"
+          - "SSH.NET"
+          - "Markdig"
+          - "Humanizer"
+          - "NGraphics"

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,17 +1,17 @@
 <Project>
   <ItemGroup>
-    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.3.3" />
-    <PackageVersion Include="Aspire.Hosting.Azure.KeyVault" Version="13.3.3" />
-    <PackageVersion Include="Aspire.Hosting.Azure.Storage" Version="13.3.3" />
-    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.3.3" />
-    <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.3.3" />
+    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.3.4" />
+    <PackageVersion Include="Aspire.Hosting.Azure.KeyVault" Version="13.3.4" />
+    <PackageVersion Include="Aspire.Hosting.Azure.Storage" Version="13.3.4" />
+    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.3.4" />
+    <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.3.4" />
     <PackageVersion Include="AWSSDK.KeyManagementService" Version="4.0.10.4" />
     <PackageVersion Include="AWSSDK.S3" Version="4.0.23.3" />
     <PackageVersion Include="AWSSDK.SecurityToken" Version="4.0.6.6" />
     <PackageVersion Include="AWSSDK.Signer" Version="4.0.3.23" />
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />
     <PackageVersion Include="Azure.Security.KeyVault.Certificates" Version="4.8.0" />
-    <PackageVersion Include="Azure.Search.Documents" Version="11.6.0" />
+    <PackageVersion Include="Azure.Search.Documents" Version="12.0.0" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.28.0" />
     <PackageVersion Include="OpenSearch.Client" Version="1.8.0" />
     <PackageVersion Include="OpenSearch.Net.Auth.AwsSigV4" Version="1.8.0" />
@@ -24,7 +24,7 @@
     <PackageVersion Include="Humanizer" Version="3.0.10" />
     <PackageVersion Include="Meziantou.Extensions.Logging.Xunit.v3" Version="2.0.1" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="10.0.8" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="10.0.8" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.Google" Version="10.0.8" />
@@ -33,7 +33,7 @@
     <PackageVersion Include="Microsoft.Extensions.Caching.Hybrid" Version="10.6.0" />
     <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.8" />
     <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageVersion Include="NuGet.Packaging" Version="7.6.0" />
     <PackageVersion Include="NuGet.Frameworks" Version="7.6.0" />
@@ -41,25 +41,25 @@
     <PackageVersion Include="NuGet.Configuration" Version="7.6.0" />
     <PackageVersion Include="Npgsql" Version="10.0.2" />
     <PackageVersion Include="NGraphics" Version="0.9.24" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.8" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.8" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8" />
-    <PackageVersion Include="Testcontainers.MsSql" Version="4.11.0" />
-    <PackageVersion Include="Testcontainers.MySql" Version="4.11.0" />
-    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.11.0" />
+    <PackageVersion Include="Testcontainers.MsSql" Version="4.12.0" />
+    <PackageVersion Include="Testcontainers.MySql" Version="4.12.0" />
+    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.12.0" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     <PackageVersion Include="MySql.EntityFrameworkCore" Version="10.0.7" />
     <PackageVersion Include="MySqlConnector" Version="2.5.0" />
-    <PackageVersion Include="System.Formats.Asn1" Version="10.0.0" />
+    <PackageVersion Include="System.Formats.Asn1" Version="10.0.8" />
     <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="10.0.8" />
-    <PackageVersion Include="System.Text.Json" Version="10.0.0" />
-    <PackageVersion Include="System.Reflection.Metadata" Version="10.0.0" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.8" />
+    <PackageVersion Include="System.Reflection.Metadata" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.1" />
   </ItemGroup>
   <ItemGroup>
@@ -79,7 +79,7 @@
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="Moq" Version="4.20.72" />
-    <PackageVersion Include="Testcontainers.XunitV3" Version="4.11.0" />
+    <PackageVersion Include="Testcontainers.XunitV3" Version="4.12.0" />
     <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />
     <PackageVersion Include="Microsoft.Testing.Platform" Version="2.2.3" />
     <PackageVersion Include="xunit.v3.runner.common" Version="3.2.2" />


### PR DESCRIPTION
## Summary
- Updates all central package versions in \Directory.Packages.props\ to the latest stable releases (Aspire 13.3.4, Testcontainers 4.12.0, Azure.Search.Documents 12.0.0, Microsoft.Extensions/System 10.0.8 alignment, etc.)
- Expands Dependabot NuGet groups so related packages update together (Aspire, Testcontainers, Azure, Microsoft stacks, OpenTelemetry, xUnit, and more)

## Test plan
- [ ] CI build passes
- [ ] Database integration tests (Testcontainers) pass
- [ ] Azure Search integration tests pass (major bump 11.x -> 12.x)

Supersedes open Dependabot PRs #588-#597.