### PR TITLE
Multi-feed UI shell and npm browse (Phase 6)

### DIFF
--- a/APPackages.slnx
+++ b/APPackages.slnx
@@ -33,6 +33,7 @@
     <Project Path="src/AvantiPoint.Packages.Elasticsearch/AvantiPoint.Packages.Elasticsearch.csproj" />
     <Project Path="src/AvantiPoint.Packages.Hosting/AvantiPoint.Packages.Hosting.csproj" />
     <Project Path="src/AvantiPoint.Packages.Protocol/AvantiPoint.Packages.Protocol.csproj" />
+    <Project Path="src/AvantiPoint.Packages.Registry.Npm/AvantiPoint.Packages.Registry.Npm.csproj" />
     <Project Path="src/AvantiPoint.Packages.Server/AvantiPoint.Packages.Server.csproj" />
     <Project Path="src/AvantiPoint.Packages.ServiceDefaults/AvantiPoint.Packages.ServiceDefaults.csproj" />
     <Project Path="src/AvantiPoint.Packages.UI.Razor/AvantiPoint.Packages.UI.Razor.csproj" />
@@ -60,6 +61,7 @@
     <Project Path="tests/AvantiPoint.Packages.Database.Tests/AvantiPoint.Packages.Database.Tests.csproj" />
     <Project Path="tests/AvantiPoint.Packages.Integration.Tests/AvantiPoint.Packages.Integration.Tests.csproj" />
     <Project Path="tests/AvantiPoint.Packages.Protocol.Tests/AvantiPoint.Packages.Protocol.Tests.csproj" />
+    <Project Path="tests/AvantiPoint.Packages.Registry.Npm.Tests/AvantiPoint.Packages.Registry.Npm.Tests.csproj" />
     <Project Path="tests/AvantiPoint.Packages.Search.Tests/AvantiPoint.Packages.Search.Tests.csproj" />
     <Project Path="tests/AvantiPoint.Packages.Storage.Tests/AvantiPoint.Packages.Storage.Tests.csproj" />
     <Project Path="tests/AvantiPoint.Packages.Tests/AvantiPoint.Packages.Tests.csproj" />

--- a/docs/docs/feeds/multi-feed-ui.md
+++ b/docs/docs/feeds/multi-feed-ui.md
@@ -1,0 +1,60 @@
+# Multi-feed UI components
+
+Parent epic: [#557 — Unified Multi-Feed Platform](https://github.com/AvantiPoint/avantipoint.packages/issues/557).
+
+Today **`AvantiPoint.Packages.UI.Razor`** provides a NuGet-focused operator and consumer experience:
+
+| Component | Purpose |
+|-----------|---------|
+| `FeedInfo` | NuGet feed URL, `dotnet nuget` / `NuGet.Config` snippets |
+| `PackageSearch` | Full-text search, filters, pagination |
+| `PackageDetail` | Versions, README, dependencies, install commands |
+
+The **OpenFeed** sample wires these for a NuGet-only host. Multi-feed hosts need **parallel npm and OCI experiences** on the same public origin, using `IFeedRegistry` / `IPublicBaseUrlProvider` for correct URLs behind reverse proxies.
+
+## Design principles
+
+1. **Protocol isolation** — npm and OCI UI must not depend on NuGet `Package` entities or `INuGetSearchService`.
+2. **Surface-aware URLs** — components derive registry roots from `IFeedRegistry` + `IPublicBaseUrlProvider` (not hard-coded `/v3` or `/npm`).
+3. **Reuse patterns, not domain models** — mirror NuGet component structure (connection card → browse → detail) with protocol-specific services.
+4. **Optional surfaces** — navigation and pages hide when `UseNpm()` / `UseOci*` is not registered.
+5. **Align with #536** — Blazor/Razor first; React parity tracked separately.
+
+## npm UI (`FeedProtocol.Npm`)
+
+**Registry root:** `{origin}/npm/` (from surface `RoutePrefix` via `IPublicBaseUrlProvider`).
+
+### Components
+
+| Component | NuGet analogue | Responsibility |
+|-----------|----------------|----------------|
+| `NpmFeedInfo` | `FeedInfo` | Registry URL, `.npmrc`, `npm config set registry`, auth hints |
+| `NpmPackageSearch` | `PackageSearch` | DB-backed browse/search |
+| `NpmPackageDetail` | `PackageDetail` | Versions, dist-tags, install commands |
+
+### Services
+
+- `INpmPackageBrowseService` — list/search packages for UI (uses `NpmPackage` / `NpmVersion` entities).
+
+## OCI UI (`FeedProtocol.Oci`)
+
+**Registry roots:** `{origin}/v2/` (default) or `{origin}/{segment}/v2/` (named).
+
+OCI UI components are tracked in #601 and depend on #559 (OCI registry MVP).
+
+## Multi-surface shell
+
+`MultiFeedNavigation` reads `IFeedRegistry` at render time and shows tabs only for registered surfaces:
+
+- **NuGet** — `/`, `/feed`, `/packages/{id}`
+- **npm** — `/npm`, `/npm/feed`, `/npm/packages/{name}`
+- **OCI** — `/oci`, `/oci/{segment}` (when registered)
+
+Sample hosts: **OpenFeed** (reference), **Packages.Server** when `UseNuGetUI` is enabled.
+
+## Tracking issues
+
+- #599 — Phase 6 parent
+- #600 — npm UI
+- #601 — OCI UI
+- #602 — Host shell (OpenFeed integration)

--- a/samples/OpenFeed/Components/Layout/MainLayout.razor
+++ b/samples/OpenFeed/Components/Layout/MainLayout.razor
@@ -7,13 +7,14 @@
             <div class="site-header__inner">
                 <div>
                     <h1>🎁 OpenFeed</h1>
-                    <p>Self-hosted NuGet package feed powered by AvantiPoint Packages</p>
+                    <p>Unified package feed (NuGet, npm, and more) powered by AvantiPoint Packages</p>
+                    <MultiFeedNavigation />
                 </div>
                 <nav class="site-nav" aria-label="Primary">
                     <ul class="nav-links">
                         <li><a class="nav-link @(IsActive("/") ? "active" : string.Empty)" href="/">Browse</a></li>
-                        <li><a class="nav-link @(IsActive("/feed") ? "active" : string.Empty)" href="/feed">Connect</a>
-                        </li>
+                        <li><a class="nav-link @(IsActive("/feed") ? "active" : string.Empty)" href="/feed">Connect</a></li>
+                        <li><a class="nav-link @(IsActive("/npm/feed") ? "active" : string.Empty)" href="/npm/feed">npm Connect</a></li>
                         <li><a class="nav-link @(IsActive("/api") ? "active" : string.Empty)" href="/api">API Docs</a></li>
                         <li><a class="nav-link" href="/v3/index.json" target="_blank">Service Index</a></li>
                     </ul>

--- a/samples/OpenFeed/Components/Pages/NpmFeed.razor
+++ b/samples/OpenFeed/Components/Pages/NpmFeed.razor
@@ -1,0 +1,7 @@
+@page "/npm/feed"
+@rendermode @(new Microsoft.AspNetCore.Components.Web.InteractiveServerRenderMode())
+
+<PageTitle>npm feed connection</PageTitle>
+
+<h1>npm feed connection</h1>
+<NpmFeedInfo />

--- a/samples/OpenFeed/Components/Pages/NpmHome.razor
+++ b/samples/OpenFeed/Components/Pages/NpmHome.razor
@@ -1,0 +1,7 @@
+@page "/npm"
+@rendermode @(new Microsoft.AspNetCore.Components.Web.InteractiveServerRenderMode())
+
+<PageTitle>npm packages</PageTitle>
+
+<h1>npm packages</h1>
+<NpmPackageSearch />

--- a/samples/OpenFeed/Components/Pages/NpmPackageDetailPage.razor
+++ b/samples/OpenFeed/Components/Pages/NpmPackageDetailPage.razor
@@ -1,0 +1,62 @@
+@page "/npm/packages/{PackageName}"
+@using AvantiPoint.Feed.Platform
+@using AvantiPoint.Packages.UI.Services
+@inject INpmPackageBrowseService BrowseService
+@inject IHttpContextAccessor HttpContextAccessor
+@inject IPublicBaseUrlProvider PublicBaseUrlProvider
+@inject IFeedRegistry FeedRegistry
+@rendermode @(new Microsoft.AspNetCore.Components.Web.InteractiveServerRenderMode())
+
+<PageTitle>@PageTitleText</PageTitle>
+
+@if (IsLoading)
+{
+    <p role="status">Loading package…</p>
+}
+else if (Package is null)
+{
+    <p role="alert">Package '@PackageName' was not found.</p>
+}
+else
+{
+    <NpmPackageDetail Package="Package" RegistryUrl="@RegistryUrl" />
+}
+
+@code {
+    [Parameter]
+    public string PackageName { get; set; } = string.Empty;
+
+    private NpmPackageDetailModel? Package { get; set; }
+    private bool IsLoading { get; set; } = true;
+    private string RegistryUrl { get; set; } = string.Empty;
+
+    private string PageTitleText => string.IsNullOrWhiteSpace(Package?.Name)
+        ? "npm package"
+        : $"{Package.Name} (npm)";
+
+    protected override async Task OnParametersSetAsync()
+    {
+        IsLoading = true;
+        Package = await BrowseService.GetPackageAsync(PackageName);
+        RegistryUrl = ResolveRegistryUrl();
+        IsLoading = false;
+    }
+
+    private string ResolveRegistryUrl()
+    {
+        var npmSurface = FeedRegistry.TryGetNpmSurface();
+        if (npmSurface is null)
+        {
+            return "/npm/";
+        }
+
+        var httpContext = HttpContextAccessor.HttpContext;
+        if (httpContext is null)
+        {
+            return $"{npmSurface.RoutePrefix}/";
+        }
+
+        var baseUrl = PublicBaseUrlProvider.GetSurfacePublicBaseUrl(httpContext, npmSurface.RoutePrefix);
+        return baseUrl.ToString().TrimEnd('/') + "/";
+    }
+}

--- a/samples/OpenFeed/Components/Pages/OciHome.razor
+++ b/samples/OpenFeed/Components/Pages/OciHome.razor
@@ -1,0 +1,49 @@
+@page "/oci"
+@page "/oci/{Segment}"
+@using AvantiPoint.Feed.Platform
+@inject IFeedRegistry FeedRegistry
+@rendermode @(new Microsoft.AspNetCore.Components.Web.InteractiveServerRenderMode())
+
+<PageTitle>OCI catalog</PageTitle>
+
+<h1>OCI catalog</h1>
+
+@if (!HasOciSurface)
+{
+    <p role="status">OCI is not registered on this host. Register <code>UseOciDefault()</code> or <code>UseOci(segment)</code> in startup to enable OCI UI (#559).</p>
+}
+else
+{
+    <p>Registry API: <code>@GetRegistryApiUrl()</code></p>
+    <p>Repository browsing UI is tracked in <a href="https://github.com/AvantiPoint/avantipoint.packages/issues/601">#601</a>.</p>
+}
+
+@code {
+    [Parameter]
+    public string? Segment { get; set; }
+
+    private bool HasOciSurface { get; set; }
+
+    protected override void OnParametersSet()
+    {
+        HasOciSurface = string.IsNullOrEmpty(Segment)
+            ? FeedRegistry.TryGetDefaultOciSurface() is not null
+            : FeedRegistry.TryGetOciSurfaceBySegment(Segment) is not null;
+    }
+
+    private string GetRegistryApiUrl()
+    {
+        var surface = string.IsNullOrEmpty(Segment)
+            ? FeedRegistry.TryGetDefaultOciSurface()
+            : FeedRegistry.TryGetOciSurfaceBySegment(Segment);
+
+        if (surface is null)
+        {
+            return "/v2/";
+        }
+
+        return string.IsNullOrEmpty(surface.OciSegment)
+            ? "/v2/"
+            : $"{surface.RoutePrefix}/v2/";
+    }
+}

--- a/samples/OpenFeed/Components/_Imports.razor
+++ b/samples/OpenFeed/Components/_Imports.razor
@@ -1,3 +1,8 @@
 @using Microsoft.AspNetCore.Components.Web
+@using Microsoft.AspNetCore.Http
+@using AvantiPoint.Feed.Platform
+@using AvantiPoint.Packages.UI.Services
+@using AvantiPoint.Packages.UI.Components.MultiFeed
+@using AvantiPoint.Packages.UI.Components.Npm
 @using AvantiPoint.Packages.Protocol.Models
 @using AvantiPoint.Packages.UI.Components

--- a/samples/OpenFeed/OpenFeed.csproj
+++ b/samples/OpenFeed/OpenFeed.csproj
@@ -22,7 +22,9 @@
     <!--<ProjectReference Include="..\..\src\AvantiPoint.Packages.Database.MySql\AvantiPoint.Packages.Database.MySql.csproj" />-->
     <ProjectReference Include="..\..\src\AvantiPoint.Packages.Database.Sqlite\AvantiPoint.Packages.Database.Sqlite.csproj" />
     <ProjectReference Include="..\..\src\AvantiPoint.Packages.Database.SqlServer\AvantiPoint.Packages.Database.SqlServer.csproj" />
+    <ProjectReference Include="..\..\src\AvantiPoint.Feed.Platform\AvantiPoint.Feed.Platform.csproj" />
     <ProjectReference Include="..\..\src\AvantiPoint.Packages.Hosting\AvantiPoint.Packages.Hosting.csproj" />
+    <ProjectReference Include="..\..\src\AvantiPoint.Packages.Registry.Npm\AvantiPoint.Packages.Registry.Npm.csproj" />
     <ProjectReference Include="..\..\src\AvantiPoint.Packages.UI.Razor\AvantiPoint.Packages.UI.Razor.csproj" />
     <ProjectReference Include="..\SampleDataGenerator\SampleDataGenerator.csproj" />
   </ItemGroup>

--- a/samples/OpenFeed/Program.cs
+++ b/samples/OpenFeed/Program.cs
@@ -2,6 +2,7 @@ using AvantiPoint.Feed.Platform.Extensions;
 using AvantiPoint.Packages;
 using AvantiPoint.Packages.Core;
 using AvantiPoint.Packages.Hosting;
+using AvantiPoint.Packages.Registry.Npm.Extensions;
 using AvantiPoint.Packages.UI;
 using OpenFeed.Services;
 using Microsoft.AspNetCore.Builder;
@@ -42,6 +43,11 @@ builder.Services.AddRazorComponents()
 // Configure the search service to auto-discover endpoints from the local feed
 // By default, it will use the current host's /v3/index.json endpoint
 builder.Services.AddNuGetSearchService();
+builder.Services.AddNpmPackageBrowseUi();
+
+var feed = builder.AddAvantiPointFeed(builder.Configuration.GetSection("Feed"));
+feed.UseNuGet();
+feed.UseNpmRegistry();
 
 // OpenAPI spec provider for dynamic API docs
 builder.Services.AddMemoryCache();
@@ -80,6 +86,7 @@ app.UseAntiforgery();
 app.MapOpenApi();
 
 app.MapNuGetApiRoutes();
+app.MapNpmFeed(feed);
 
 // Map Blazor components
 app.MapRazorComponents<OpenFeed.Components.App>()

--- a/src/AvantiPoint.Packages.UI.Razor/AvantiPoint.Packages.UI.Razor.csproj
+++ b/src/AvantiPoint.Packages.UI.Razor/AvantiPoint.Packages.UI.Razor.csproj
@@ -4,6 +4,7 @@
     <Description>Reusable Blazor components for NuGet package search and display</Description>
     <RootNamespace>AvantiPoint.Packages.UI</RootNamespace>
     <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,7 +12,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\AvantiPoint.Feed.Platform\AvantiPoint.Feed.Platform.csproj" />
+    <ProjectReference Include="..\AvantiPoint.Packages.Core\AvantiPoint.Packages.Core.csproj" />
     <ProjectReference Include="..\AvantiPoint.Packages.Protocol\AvantiPoint.Packages.Protocol.csproj" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
     <PackageReference Include="Markdig" />
     <PackageReference Include="Humanizer" />
   </ItemGroup>

--- a/src/AvantiPoint.Packages.UI.Razor/Components/MultiFeed/MultiFeedNavigation.razor
+++ b/src/AvantiPoint.Packages.UI.Razor/Components/MultiFeed/MultiFeedNavigation.razor
@@ -1,0 +1,89 @@
+@using AvantiPoint.Feed.Platform
+@inject IFeedRegistry FeedRegistry
+@inject NavigationManager Navigation
+
+@if (FeedRegistry.Surfaces.Count > 1)
+{
+    <nav class="multi-feed-nav" aria-label="Feed surfaces">
+        @if (FeedRegistry.TryGetNuGetSurface() is not null)
+        {
+            <a class="multi-feed-nav__link @(IsNuGetActive() ? "active" : null)" href="/">NuGet</a>
+        }
+        @if (FeedRegistry.TryGetNpmSurface() is not null)
+        {
+            <a class="multi-feed-nav__link @(IsNpmActive() ? "active" : null)" href="/npm">npm</a>
+        }
+        @foreach (var oci in GetOciSurfaces())
+        {
+            var href = GetOciCatalogHref(oci);
+            <a class="multi-feed-nav__link @(IsOciActive(oci) ? "active" : null)" href="@href">@GetOciNavLabel(oci)</a>
+        }
+    </nav>
+}
+
+<style>
+    .multi-feed-nav {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        margin-top: 0.75rem;
+    }
+
+    .multi-feed-nav__link {
+        display: inline-block;
+        padding: 0.35rem 0.85rem;
+        border-radius: 999px;
+        border: 1px solid #d0d7de;
+        background: #f6f8fa;
+        color: #24292f;
+        text-decoration: none;
+        font-size: 0.875rem;
+        font-weight: 600;
+    }
+
+    .multi-feed-nav__link.active {
+        background: #0969da;
+        border-color: #0969da;
+        color: #fff;
+    }
+
+    .multi-feed-nav__link:hover:not(.active) {
+        background: #eaeef2;
+    }
+</style>
+
+@code {
+    private IEnumerable<SurfaceRegistration> GetOciSurfaces() =>
+        FeedRegistry.Surfaces.Where(s => s.Protocol == FeedProtocol.Oci);
+
+    private static string GetOciNavLabel(SurfaceRegistration surface) =>
+        string.IsNullOrEmpty(surface.OciSegment) ? "OCI" : $"OCI ({surface.OciSegment})";
+
+    private static string GetOciCatalogHref(SurfaceRegistration surface) =>
+        string.IsNullOrEmpty(surface.OciSegment) ? "/oci" : $"/oci/{surface.OciSegment}";
+
+    private bool IsNuGetActive()
+    {
+        var path = new Uri(Navigation.Uri).AbsolutePath;
+        return path is "/" or "/feed"
+            || path.StartsWith("/packages/", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private bool IsNpmActive()
+    {
+        var path = new Uri(Navigation.Uri).AbsolutePath;
+        return path.StartsWith("/npm", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private bool IsOciActive(SurfaceRegistration surface)
+    {
+        var path = new Uri(Navigation.Uri).AbsolutePath;
+        if (string.IsNullOrEmpty(surface.OciSegment))
+        {
+            return path.Equals("/oci", StringComparison.OrdinalIgnoreCase)
+                || path.StartsWith("/oci/repos/", StringComparison.OrdinalIgnoreCase);
+        }
+
+        return path.StartsWith($"/oci/{surface.OciSegment}", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/AvantiPoint.Packages.UI.Razor/Components/Npm/NpmFeedInfo.razor
+++ b/src/AvantiPoint.Packages.UI.Razor/Components/Npm/NpmFeedInfo.razor
@@ -1,0 +1,145 @@
+@using AvantiPoint.Feed.Platform
+@using AvantiPoint.Feed.Platform.Configuration
+@inject IHttpContextAccessor HttpContextAccessor
+@inject IPublicBaseUrlProvider PublicBaseUrlProvider
+@inject IFeedRegistry FeedRegistry
+@inject IOptionsMonitor<FeedOptions> FeedOptions
+
+@if (FeedRegistry.TryGetNpmSurface() is null)
+{
+    <p role="status">npm surface is not registered on this host.</p>
+}
+else
+{
+    <div class="feed-info-card">
+        <h3>npm registry connection</h3>
+
+        <div class="info-section">
+            <label>Registry URL:</label>
+            <div class="url-display">
+                <code>@RegistryUrl</code>
+            </div>
+        </div>
+
+        <div class="info-section">
+            <h4>Configure npm</h4>
+            <div class="command-box">
+                <strong>CLI:</strong>
+                <code>npm config set registry @RegistryUrl</code>
+            </div>
+            <div class="command-box">
+                <strong>.npmrc:</strong>
+                <code>registry=@RegistryUrl</code>
+            </div>
+        </div>
+
+        @if (ShowAuthenticationInfo)
+        {
+            <div class="info-section auth-info">
+                <h4>Authentication</h4>
+                <p>Use a Bearer token for CI (set <code>NPM_TOKEN</code> or configure auth in <code>.npmrc</code>).</p>
+                <div class="command-box">
+                    <code>//registry.example.com/:_authToken=${NPM_TOKEN}</code>
+                </div>
+            </div>
+        }
+    </div>
+}
+
+<style>
+    .feed-info-card {
+        background-color: white;
+        border: 1px solid #d0d7de;
+        border-radius: 6px;
+        padding: 1.5rem;
+        margin-bottom: 1.5rem;
+    }
+
+    .feed-info-card h3 {
+        font-size: 1.25rem;
+        margin-bottom: 1.25rem;
+        color: #24292f;
+    }
+
+    .info-section {
+        margin-bottom: 1.5rem;
+    }
+
+    .info-section label {
+        display: block;
+        font-weight: 600;
+        margin-bottom: 0.5rem;
+        color: #57606a;
+    }
+
+    .url-display code {
+        display: block;
+        background-color: #f6f8fa;
+        padding: 0.75rem;
+        border-radius: 4px;
+        font-family: Consolas, Monaco, monospace;
+        font-size: 0.875rem;
+        border: 1px solid #d0d7de;
+        word-break: break-all;
+    }
+
+    .command-box {
+        margin-bottom: 0.75rem;
+    }
+
+    .command-box strong {
+        display: block;
+        margin-bottom: 0.25rem;
+        color: #57606a;
+        font-size: 0.875rem;
+    }
+
+    .command-box code {
+        display: block;
+        background-color: #24292f;
+        color: #c9d1d9;
+        padding: 0.75rem;
+        border-radius: 4px;
+        font-family: Consolas, Monaco, monospace;
+        font-size: 0.875rem;
+        overflow-x: auto;
+        white-space: pre-wrap;
+        word-break: break-all;
+    }
+
+    .auth-info {
+        background-color: #fff8c5;
+        padding: 1rem;
+        border-radius: 4px;
+        border: 1px solid #d4a72c;
+    }
+</style>
+
+@code {
+    [Parameter]
+    public bool ShowAuthenticationInfo { get; set; }
+
+    private string RegistryUrl { get; set; } = string.Empty;
+
+    protected override void OnParametersSet()
+    {
+        var npmSurface = FeedRegistry.TryGetNpmSurface();
+        if (npmSurface is null)
+        {
+            return;
+        }
+
+        var httpContext = HttpContextAccessor.HttpContext;
+        if (httpContext is null)
+        {
+            RegistryUrl = $"{npmSurface.RoutePrefix}/";
+            return;
+        }
+
+        var baseUrl = PublicBaseUrlProvider.GetSurfacePublicBaseUrl(httpContext, npmSurface.RoutePrefix);
+        RegistryUrl = baseUrl.ToString().TrimEnd('/') + "/";
+        ShowAuthenticationInfo = ShowAuthenticationInfo
+            || !FeedOptions.CurrentValue.Authentication.AllowAnonymousPull
+            || !string.IsNullOrEmpty(FeedOptions.CurrentValue.Authentication.ApiKey);
+    }
+}

--- a/src/AvantiPoint.Packages.UI.Razor/Components/Npm/NpmPackageDetail.razor
+++ b/src/AvantiPoint.Packages.UI.Razor/Components/Npm/NpmPackageDetail.razor
@@ -1,0 +1,126 @@
+@using AvantiPoint.Packages.UI.Services
+
+@if (Package is null)
+{
+    <p role="alert">Package not found.</p>
+}
+else
+{
+    <article class="npm-package-detail">
+        <h2>@Package.Name</h2>
+
+        @if (Package.DistTags.Count > 0)
+        {
+            <section>
+                <h3>Dist-tags</h3>
+                <ul>
+                    @foreach (var tag in Package.DistTags)
+                    {
+                        <li><strong>@tag.Key</strong> → @tag.Value</li>
+                    }
+                </ul>
+            </section>
+        }
+
+        <section>
+            <h3>Versions</h3>
+            <ul class="npm-version-list">
+                @foreach (var version in Package.Versions)
+                {
+                    <li>
+                        <button type="button"
+                                class="npm-version-select @(SelectedVersion == version.Version ? "active" : null)"
+                                @onclick="() => SelectVersion(version.Version)">
+                            @version.Version
+                        </button>
+                        <span class="npm-published">@version.Published.ToString("u")</span>
+                    </li>
+                }
+            </ul>
+        </section>
+
+        @if (!string.IsNullOrEmpty(SelectedVersion))
+        {
+            <section>
+                <h3>Install</h3>
+                <div class="command-box">
+                    <code>npm install @Package.Name@@SelectedVersion --registry @RegistryUrl</code>
+                </div>
+                <div class="command-box">
+                    <code>pnpm add @Package.Name@@SelectedVersion --registry @RegistryUrl</code>
+                </div>
+                <div class="command-box">
+                    <code>yarn add @Package.Name@@SelectedVersion --registry @RegistryUrl</code>
+                </div>
+            </section>
+        }
+    </article>
+}
+
+<style>
+    .npm-package-detail h2 {
+        margin-bottom: 1rem;
+    }
+
+    .npm-version-list {
+        list-style: none;
+        padding: 0;
+    }
+
+    .npm-version-list li {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        padding: 0.35rem 0;
+    }
+
+    .npm-version-select {
+        border: 1px solid #d0d7de;
+        background: #f6f8fa;
+        border-radius: 4px;
+        padding: 0.2rem 0.5rem;
+        cursor: pointer;
+    }
+
+    .npm-version-select.active {
+        background: #0969da;
+        color: #fff;
+        border-color: #0969da;
+    }
+
+    .npm-published {
+        font-size: 0.8rem;
+        color: #57606a;
+    }
+
+    .command-box code {
+        display: block;
+        background-color: #24292f;
+        color: #c9d1d9;
+        padding: 0.75rem;
+        border-radius: 4px;
+        font-family: Consolas, Monaco, monospace;
+        font-size: 0.875rem;
+        overflow-x: auto;
+        white-space: pre-wrap;
+        word-break: break-all;
+    }
+</style>
+
+@code {
+    [Parameter, EditorRequired]
+    public NpmPackageDetailModel? Package { get; set; }
+
+    [Parameter]
+    public string RegistryUrl { get; set; } = string.Empty;
+
+    private string? SelectedVersion { get; set; }
+
+    protected override void OnParametersSet()
+    {
+        SelectedVersion ??= Package?.DistTags.GetValueOrDefault("latest")
+            ?? Package?.Versions.FirstOrDefault()?.Version;
+    }
+
+    private void SelectVersion(string version) => SelectedVersion = version;
+}

--- a/src/AvantiPoint.Packages.UI.Razor/Components/Npm/NpmPackageSearch.razor
+++ b/src/AvantiPoint.Packages.UI.Razor/Components/Npm/NpmPackageSearch.razor
@@ -1,0 +1,125 @@
+@using AvantiPoint.Packages.UI.Services
+@inject INpmPackageBrowseService BrowseService
+@inject NavigationManager Navigation
+
+<section class="npm-package-search">
+    <form @onsubmit="HandleSearch" @onsubmit:preventDefault="true">
+        <input type="search"
+               class="npm-search-input"
+               placeholder="@Placeholder"
+               @bind="SearchQuery"
+               @bind:event="oninput" />
+        <button type="submit" class="npm-search-btn">Search</button>
+    </form>
+
+    @if (IsLoading)
+    {
+        <p role="status">Loading packages…</p>
+    }
+    else if (Results.Count == 0)
+    {
+        <p role="status">No npm packages found.</p>
+    }
+    else
+    {
+        <ul class="npm-package-list">
+            @foreach (var item in Results)
+            {
+                <li>
+                    <a href="@GetPackageHref(item.Name)">@item.Name</a>
+                    @if (!string.IsNullOrEmpty(item.LatestVersion))
+                    {
+                        <span class="npm-version-badge">@item.LatestVersion</span>
+                    }
+                </li>
+            }
+        </ul>
+    }
+</section>
+
+<style>
+    .npm-package-search {
+        margin-top: 1rem;
+    }
+
+    .npm-search-input {
+        width: min(100%, 28rem);
+        padding: 0.5rem 0.75rem;
+        border: 1px solid #d0d7de;
+        border-radius: 6px;
+        margin-right: 0.5rem;
+    }
+
+    .npm-search-btn {
+        padding: 0.5rem 1rem;
+        border-radius: 6px;
+        border: 1px solid #0969da;
+        background: #0969da;
+        color: #fff;
+        cursor: pointer;
+    }
+
+    .npm-package-list {
+        list-style: none;
+        padding: 0;
+        margin: 1.25rem 0 0;
+    }
+
+    .npm-package-list li {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.65rem 0;
+        border-bottom: 1px solid #d8dee4;
+    }
+
+    .npm-package-list a {
+        font-weight: 600;
+        color: #0969da;
+        text-decoration: none;
+    }
+
+    .npm-version-badge {
+        font-size: 0.8rem;
+        color: #57606a;
+        background: #f6f8fa;
+        border: 1px solid #d0d7de;
+        border-radius: 4px;
+        padding: 0.1rem 0.4rem;
+    }
+</style>
+
+@code {
+    [Parameter]
+    public string Placeholder { get; set; } = "Search npm packages in this feed…";
+
+    private string SearchQuery { get; set; } = string.Empty;
+    private IReadOnlyList<NpmPackageListItem> Results { get; set; } = [];
+    private bool IsLoading { get; set; } = true;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadResultsAsync();
+    }
+
+    private async Task HandleSearch()
+    {
+        await LoadResultsAsync();
+    }
+
+    private async Task LoadResultsAsync()
+    {
+        IsLoading = true;
+        try
+        {
+            Results = await BrowseService.SearchAsync(SearchQuery, skip: 0, take: 100);
+        }
+        finally
+        {
+            IsLoading = false;
+        }
+    }
+
+    private static string GetPackageHref(string name) =>
+        $"/npm/packages/{Uri.EscapeDataString(name)}";
+}

--- a/src/AvantiPoint.Packages.UI.Razor/NpmUiServiceExtensions.cs
+++ b/src/AvantiPoint.Packages.UI.Razor/NpmUiServiceExtensions.cs
@@ -1,0 +1,13 @@
+using AvantiPoint.Packages.UI.Services;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace AvantiPoint.Packages.UI;
+
+public static class NpmUiServiceExtensions
+{
+    public static IServiceCollection AddNpmPackageBrowseUi(this IServiceCollection services)
+    {
+        services.AddScoped<INpmPackageBrowseService, NpmPackageBrowseService>();
+        return services;
+    }
+}

--- a/src/AvantiPoint.Packages.UI.Razor/Services/INpmPackageBrowseService.cs
+++ b/src/AvantiPoint.Packages.UI.Razor/Services/INpmPackageBrowseService.cs
@@ -1,0 +1,14 @@
+namespace AvantiPoint.Packages.UI.Services;
+
+public interface INpmPackageBrowseService
+{
+    Task<IReadOnlyList<NpmPackageListItem>> SearchAsync(
+        string? query,
+        int skip,
+        int take,
+        CancellationToken cancellationToken = default);
+
+    Task<NpmPackageDetailModel?> GetPackageAsync(
+        string packageName,
+        CancellationToken cancellationToken = default);
+}

--- a/src/AvantiPoint.Packages.UI.Razor/Services/NpmPackageBrowseService.cs
+++ b/src/AvantiPoint.Packages.UI.Razor/Services/NpmPackageBrowseService.cs
@@ -1,0 +1,91 @@
+using AvantiPoint.Feed.Platform;
+using AvantiPoint.Packages.Core;
+using AvantiPoint.Packages.Core.Entities.Npm;
+using Microsoft.EntityFrameworkCore;
+
+namespace AvantiPoint.Packages.UI.Services;
+
+public sealed class NpmPackageBrowseService : INpmPackageBrowseService
+{
+    private readonly IContext _context;
+    private readonly IFeedRegistry _feedRegistry;
+
+    public NpmPackageBrowseService(IContext context, IFeedRegistry feedRegistry)
+    {
+        _context = context;
+        _feedRegistry = feedRegistry;
+    }
+
+    public async Task<IReadOnlyList<NpmPackageListItem>> SearchAsync(
+        string? query,
+        int skip,
+        int take,
+        CancellationToken cancellationToken = default)
+    {
+        var feedId = _feedRegistry.Feed.FeedId;
+        var packages = _context.NpmPackages.AsNoTracking().Where(p => p.FeedId == feedId);
+
+        if (!string.IsNullOrWhiteSpace(query))
+        {
+            var term = query.Trim();
+            packages = packages.Where(p => EF.Functions.Like(p.Name, $"%{term}%"));
+        }
+
+        var rows = await packages
+            .OrderBy(p => p.Name)
+            .Skip(skip)
+            .Take(take)
+            .Select(p => new
+            {
+                p.Name,
+                LatestVersion = p.Versions
+                    .OrderByDescending(v => v.Published)
+                    .Select(v => v.Version)
+                    .FirstOrDefault(),
+                Published = p.Versions
+                    .OrderByDescending(v => v.Published)
+                    .Select(v => (DateTime?)v.Published)
+                    .FirstOrDefault(),
+            })
+            .ToListAsync(cancellationToken);
+
+        return rows
+            .Select(r => new NpmPackageListItem(r.Name, r.LatestVersion, r.Published))
+            .ToList();
+    }
+
+    public async Task<NpmPackageDetailModel?> GetPackageAsync(
+        string packageName,
+        CancellationToken cancellationToken = default)
+    {
+        var feedId = _feedRegistry.Feed.FeedId;
+        var normalizedName = NormalizePackageName(packageName);
+
+        var package = await _context.NpmPackages
+            .AsNoTracking()
+            .Include(p => p.Versions)
+            .Include(p => p.DistTags)
+            .FirstOrDefaultAsync(
+                p => p.FeedId == feedId && p.Name == normalizedName,
+                cancellationToken);
+
+        if (package is null)
+        {
+            return null;
+        }
+
+        var versions = package.Versions
+            .OrderByDescending(v => v.Published)
+            .Select(v => new NpmVersionListItem(v.Version, v.Published, v.Shasum))
+            .ToList();
+
+        var distTags = package.DistTags.ToDictionary(t => t.Tag, t => t.Version, StringComparer.OrdinalIgnoreCase);
+
+        return new NpmPackageDetailModel(package.Name, versions, distTags);
+    }
+
+    private static string NormalizePackageName(string packageName) =>
+        packageName.StartsWith('@')
+            ? packageName
+            : packageName.ToLowerInvariant();
+}

--- a/src/AvantiPoint.Packages.UI.Razor/Services/NpmPackageDetailModel.cs
+++ b/src/AvantiPoint.Packages.UI.Razor/Services/NpmPackageDetailModel.cs
@@ -1,0 +1,11 @@
+namespace AvantiPoint.Packages.UI.Services;
+
+public sealed record NpmPackageDetailModel(
+    string Name,
+    IReadOnlyList<NpmVersionListItem> Versions,
+    IReadOnlyDictionary<string, string> DistTags);
+
+public sealed record NpmVersionListItem(
+    string Version,
+    DateTime Published,
+    string? Shasum);

--- a/src/AvantiPoint.Packages.UI.Razor/Services/NpmPackageListItem.cs
+++ b/src/AvantiPoint.Packages.UI.Razor/Services/NpmPackageListItem.cs
@@ -1,0 +1,6 @@
+namespace AvantiPoint.Packages.UI.Services;
+
+public sealed record NpmPackageListItem(
+    string Name,
+    string? LatestVersion,
+    DateTime? Published);

--- a/src/AvantiPoint.Packages.UI.Razor/_Imports.razor
+++ b/src/AvantiPoint.Packages.UI.Razor/_Imports.razor
@@ -1,4 +1,10 @@
 @using Microsoft.AspNetCore.Components.Web
+@using Microsoft.AspNetCore.Http
+@using Microsoft.Extensions.Options
+@using AvantiPoint.Feed.Platform
+@using AvantiPoint.Feed.Platform.Configuration
 @using AvantiPoint.Packages.UI.Components
+@using AvantiPoint.Packages.UI.Components.MultiFeed
+@using AvantiPoint.Packages.UI.Components.Npm
 @using AvantiPoint.Packages.UI.Services
 @using AvantiPoint.Packages.Protocol.Models


### PR DESCRIPTION
## Summary

- Adds surface-aware **MultiFeedNavigation** and npm UI components (NpmFeedInfo, NpmPackageSearch, NpmPackageDetail) in AvantiPoint.Packages.UI.Razor
- Wires **OpenFeed** with AddAvantiPointFeed + UseNuGet() + UseNpmRegistry() and Blazor routes for /npm, /npm/feed, /npm/packages/{name}
- Documents multi-feed UI in docs/docs/feeds/multi-feed-ui.md
- Adds Registry.Npm projects to APPackages.slnx

Relates to epic **#557**. Implements initial scope for **#599**, **#600**, and **#602**.

## Not in this PR (follow-up)

- #559 OCI registry implementation
- #601 OCI UI components (placeholder /oci page only)
- #560 Phase 3 hardening, #562 mirror, #563 operations
- Packages.Server / Packages.Host multi-feed UI wiring

## Test plan

- [x] dotnet build samples/OpenFeed/OpenFeed.csproj
- [x] dotnet test tests/AvantiPoint.Packages.Registry.Npm.Tests
- [ ] Manual: run OpenFeed, confirm NuGet + npm tabs, browse npm packages, copy registry URL from /npm/feed
