### PR TITLE
Docs: mirror/deployment scenarios and origin integration tests

### DIFF
--- a/docs/docs/comparison.md
+++ b/docs/docs/comparison.md
@@ -354,7 +354,10 @@ Bagetter continues the community-driven evolution of BaGet with broad compatibil
 
 ## Getting Help
 
-- **AvantiPoint Packages**: [GitHub Issues](https://github.com/AvantiPoint/avantipoint.packages/issues) for bug reports | [GitHub repository](https://github.com/AvantiPoint/avantipoint.packages)
-- **Bagetter**: [Discord](https://discord.gg/XsAmm6f2hZ) | [GitHub](https://github.com/bagetter/Bagetter)
-- **BaGet**: [Discord](https://discord.gg/MWbhpf66mk) | [GitHub](https://github.com/loic-sharma/BaGet)
-- **NuGet.Server**: [NuGet Gallery Issues](https://github.com/nuget/NuGetGallery/issues)
+**AvantiPoint Packages** — Report bugs, request features, or ask questions about this product via [GitHub Issues](https://github.com/AvantiPoint/avantipoint.packages/issues) in [our repository](https://github.com/AvantiPoint/avantipoint.packages).
+
+**Learn more about alternatives** — The other servers compared on this page are separate projects. Use their community resources to explore those options, not to get support for AvantiPoint Packages:
+
+- **Bagetter**: [GitHub repository](https://github.com/bagetter/Bagetter) · [Discord community](https://discord.gg/XsAmm6f2hZ)
+- **BaGet**: [GitHub repository](https://github.com/loic-sharma/BaGet) · [Discord community](https://discord.gg/MWbhpf66mk)
+- **NuGet.Server**: [NuGet.Server package](https://www.nuget.org/packages/NuGet.Server) · [NuGet Gallery repository](https://github.com/NuGet/NuGetGallery)

--- a/docs/docs/comparison.md
+++ b/docs/docs/comparison.md
@@ -354,7 +354,7 @@ Bagetter continues the community-driven evolution of BaGet with broad compatibil
 
 ## Getting Help
 
-- **AvantiPoint Packages**: [GitHub Issues](https://github.com/AvantiPoint/avantipoint.packages/issues)
+- **AvantiPoint Packages**: [GitHub repository](https://github.com/AvantiPoint/avantipoint.packages)
 - **Bagetter**: [Discord](https://discord.gg/XsAmm6f2hZ) | [GitHub](https://github.com/bagetter/Bagetter)
 - **BaGet**: [Discord](https://discord.gg/MWbhpf66mk) | [GitHub](https://github.com/loic-sharma/BaGet)
-- **NuGet.Server**: [NuGet Gallery Issues](https://github.com/nuget/NuGetGallery/issues)
+- **NuGet.Server**: [NuGet Gallery repository](https://github.com/nuget/NuGetGallery)

--- a/docs/docs/comparison.md
+++ b/docs/docs/comparison.md
@@ -354,7 +354,7 @@ Bagetter continues the community-driven evolution of BaGet with broad compatibil
 
 ## Getting Help
 
-- **AvantiPoint Packages**: [GitHub repository](https://github.com/AvantiPoint/avantipoint.packages)
+- **AvantiPoint Packages**: [GitHub Issues](https://github.com/AvantiPoint/avantipoint.packages/issues) for bug reports | [GitHub repository](https://github.com/AvantiPoint/avantipoint.packages)
 - **Bagetter**: [Discord](https://discord.gg/XsAmm6f2hZ) | [GitHub](https://github.com/bagetter/Bagetter)
 - **BaGet**: [Discord](https://discord.gg/MWbhpf66mk) | [GitHub](https://github.com/loic-sharma/BaGet)
-- **NuGet.Server**: [NuGet Gallery repository](https://github.com/nuget/NuGetGallery)
+- **NuGet.Server**: [NuGet Gallery Issues](https://github.com/nuget/NuGetGallery/issues)

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -310,26 +310,31 @@ options.AddAwsS3Storage();
 
 ## Upstream Mirrors
 
-Configure upstream package sources to mirror or proxy:
-
-### Via Configuration
+Configure upstream package sources to mirror or proxy. In v4, sources are `PackageSource` entities with a per-source `CachingStrategy` (`IndexAndCache`, `CacheOnly`, or `ProxyOnly`).
 
 ```json
 {
-  "Mirror": {
-    "NuGet.org": {
-      "FeedUrl": "https://api.nuget.org/v3/index.json"
-    },
-    "Telerik": {
-      "FeedUrl": "https://nuget.telerik.com/nuget",
-      "Username": "user@example.com",
-      "ApiToken": "your-password"
+  "PackageSources": [
+    {
+      "Name": "NuGet.org",
+      "FeedUrl": "https://api.nuget.org/v3/index.json",
+      "Type": "Upstream",
+      "CachingStrategy": "IndexAndCache",
+      "IsEnabled": true
     }
+  ],
+  "Search": {
+    "Type": "Database",
+    "IncludeMirroredPackages": true
   }
 }
 ```
 
-### Via Code
+Configure `PackageSource` rows via the Host UI (`/Account/PackageSources`), database seeding, or `Mirror:NuGetConfigPath`. Combine `CachingStrategy` with `Search.IncludeMirroredPackages` per [Deployment Scenarios](deployment-scenarios.md).
+
+> **Deprecated:** The legacy `Mirror` dictionary and `AddUpstreamSource` code helpers are deprecated in v4.0. See [Upstream Mirrors](mirrors.md) for migration guidance.
+
+### Via Code (deprecated)
 
 ```csharp
 builder.Services.AddNuGetPackageApi(options =>
@@ -337,7 +342,7 @@ builder.Services.AddNuGetPackageApi(options =>
     options.AddFileStorage();
     options.AddSqliteDatabase("Sqlite");
     
-    // Add upstream sources
+    // Deprecated in v4 — use PackageSources instead
     options.AddUpstreamSource("NuGet.org", "https://api.nuget.org/v3/index.json");
     options.AddUpstreamSource("Telerik", "https://nuget.telerik.com/nuget", "user@example.com", "password");
 });
@@ -379,9 +384,9 @@ Allow or disallow package deletion (default: allow):
 }
 ```
 
-### Search
+### Search and discovery
 
-Configure package search behavior:
+Configure package search behavior and which package origins appear in browse/search results:
 
 ```json
 {
@@ -392,7 +397,29 @@ Configure package search behavior:
 }
 ```
 
-When `IncludeMirroredPackages` is `false`, search and registration discovery return only packages published directly to this feed (`Published` origin). Mirrored packages remain available for restore but are hidden from browse/search. Defaults to `true`.
+#### `IncludeMirroredPackages`
+
+Controls whether mirrored upstream packages appear in search, autocomplete, and registration discovery. Defaults to `true`.
+
+| Value | Search includes | Restore behavior |
+|-------|-----------------|------------------|
+| `true` (default) | `Published` and `Mirrored` packages | All origins available for restore |
+| `false` | `Published` packages only | Mirrored and cached packages still restorable by id/version |
+
+Packages with origin `Cached` (`CacheOnly` strategy) are **never** included in search, regardless of this setting.
+
+This setting works together with per-source `CachingStrategy` on `PackageSources`. See [Deployment Scenarios](deployment-scenarios.md) for recommended combinations.
+
+**Defaults that preserve existing behavior:**
+
+- `Search.IncludeMirroredPackages` defaults to `true`
+- `PackageSource.CachingStrategy` defaults to `IndexAndCache`
+
+No changes are required when upgrading unless you want a different deployment pattern (commercial/private feed, lightweight Docker, etc.).
+
+#### Search provider type
+
+`Search.Type` selects the search backend: `Database` (default), `Null`, `AzureSearch`, `OpenSearch`, or `Elasticsearch`. External search providers honor the same origin filters via `IncludeMirroredPackages`.
 
 ### Repository Package Signing
 
@@ -491,6 +518,7 @@ await app.RunAsync();
 
 ## See Also
 
+- [Deployment Scenarios](deployment-scenarios.md) - Commercial, enterprise mirror, and lightweight dev/Docker patterns
 - [Database](database/index.md) - Detailed database configuration
 - [Storage](storage/index.md) - Detailed storage configuration
 - [Upstream Mirrors](mirrors.md) - Detailed mirror configuration

--- a/docs/docs/deployment-scenarios.md
+++ b/docs/docs/deployment-scenarios.md
@@ -1,0 +1,218 @@
+---
+id: deployment-scenarios
+title: Deployment Scenarios
+sidebar_label: Deployment Scenarios
+sidebar_position: 5
+---
+
+This guide describes common feed deployment patterns from [epic #535](https://github.com/AvantiPoint/avantipoint.packages/issues/535). Each scenario combines `PackageSources` caching strategies with `Search.IncludeMirroredPackages` to control what appears in browse/search versus what is available for restore.
+
+For strategy details and the full behavior matrix, see [Upstream Mirrors](mirrors.md#caching-strategies-packagesourcecachingstrategy).
+
+## How search and mirrors work together
+
+Two settings control discovery versus restore:
+
+| Setting | Location | Default | Effect |
+|---------|----------|---------|--------|
+| `CachingStrategy` | Per `PackageSource` | `IndexAndCache` | Controls disk usage, database metadata, and package origin |
+| `IncludeMirroredPackages` | `Search` section | `true` | Controls whether `Mirrored` packages appear in search and registration discovery |
+
+**Package origins:**
+
+- `Published` — pushed directly to this feed; always eligible for search (when listed)
+- `Mirrored` — downloaded and indexed from upstream (`IndexAndCache`); included in search when `IncludeMirroredPackages` is `true`
+- `Cached` — stored for restore only (`CacheOnly`); never included in search
+
+Packages from `ProxyOnly` sources are not stored locally and never appear in search.
+
+## Strategy × search × disk matrix
+
+| Caching strategy | `IncludeMirroredPackages: true` | `IncludeMirroredPackages: false` | Disk usage |
+|------------------|--------------------------------|----------------------------------|------------|
+| `IndexAndCache` | Appears in search | Hidden from search; restore works | Full (binary + metadata) |
+| `CacheOnly` | Never in search | Never in search | Binary only (no DB/search) |
+| `ProxyOnly` | Never in search | Never in search | None |
+| Published (direct push) | Appears in search | Appears in search | Full |
+
+Configure `PackageSource` rows via the Host UI (`/Account/PackageSources`), database seeding, or `Mirror:NuGetConfigPath`. The examples below show the equivalent `appsettings.json` values for each scenario.
+
+---
+
+## Commercial / private feed
+
+**Goal:** Show only packages published to your feed in search, while still allowing clients to restore upstream dependencies (NuGet.org, commercial feeds, etc.) with minimal disk usage.
+
+**Pattern:** `Search.IncludeMirroredPackages: false` + `ProxyOnly` (or `CacheOnly` if you want faster repeat restores without search visibility).
+
+```json
+{
+  "Database": {
+    "Type": "SqlServer"
+  },
+  "Storage": {
+    "Type": "FileStorage",
+    "Path": "App_Data"
+  },
+  "ConnectionStrings": {
+    "SqlServer": "Server=...;Database=packages;..."
+  },
+  "Search": {
+    "Type": "Database",
+    "IncludeMirroredPackages": false
+  },
+  "PackageSources": [
+    {
+      "Name": "NuGet.org",
+      "FeedUrl": "https://api.nuget.org/v3/index.json",
+      "Type": "Upstream",
+      "CachingStrategy": "ProxyOnly",
+      "MirrorSignaturePolicy": "Merge",
+      "IsEnabled": true
+    },
+    {
+      "Name": "Telerik",
+      "FeedUrl": "https://nuget.telerik.com/nuget",
+      "Type": "Upstream",
+      "CachingStrategy": "ProxyOnly",
+      "MirrorSignaturePolicy": "Resign",
+      "Username": "user@example.com",
+      "Password": "your-api-key",
+      "IsEnabled": true
+    }
+  ]
+}
+```
+
+**Alternative with local cache:** Replace `ProxyOnly` with `CacheOnly` on upstream sources if you want faster repeat restores without adding packages to search. Disk usage grows with unique restored packages but stays lower than full indexing (no database metadata or search index entries).
+
+---
+
+## Enterprise mirror
+
+**Goal:** Provide a single feed URL that includes both internally published packages and mirrored upstream packages in search—typical for corporate artifact hubs and offline-capable mirrors.
+
+**Pattern:** `Search.IncludeMirroredPackages: true` (default) + `IndexAndCache` on upstream sources.
+
+```json
+{
+  "Database": {
+    "Type": "SqlServer"
+  },
+  "Storage": {
+    "Type": "AzureBlobStorage",
+    "Container": "packages",
+    "ConnectionString": "DefaultEndpointsProtocol=https;AccountName=...;"
+  },
+  "ConnectionStrings": {
+    "SqlServer": "Server=...;Database=packages;..."
+  },
+  "Search": {
+    "Type": "Database",
+    "IncludeMirroredPackages": true
+  },
+  "PackageSources": [
+    {
+      "Name": "NuGet.org",
+      "FeedUrl": "https://api.nuget.org/v3/index.json",
+      "Type": "Both",
+      "CachingStrategy": "IndexAndCache",
+      "MirrorSignaturePolicy": "Merge",
+      "IsEnabled": true
+    },
+    {
+      "Name": "InternalUpstream",
+      "FeedUrl": "https://nuget.internal.example.com/v3/index.json",
+      "Type": "Upstream",
+      "CachingStrategy": "IndexAndCache",
+      "MirrorSignaturePolicy": "TrustedCerts",
+      "IsEnabled": true
+    }
+  ],
+  "Shields": {
+    "ServerName": "Contoso Packages"
+  }
+}
+```
+
+This is the **default behavior** for existing deployments: upstream packages are indexed and appear in search alongside published packages.
+
+---
+
+## Lightweight dev / Docker
+
+**Goal:** Run a small feed for local development or containerized CI with published packages visible in search, upstream restore available, and minimal disk footprint.
+
+**Pattern:** `Search.IncludeMirroredPackages: false` + `CacheOnly` or `ProxyOnly` on upstream sources. Point clients at the feed URL; upstream dependencies resolve transparently on restore.
+
+```json
+{
+  "Database": {
+    "Type": "Sqlite"
+  },
+  "Storage": {
+    "Type": "FileStorage",
+    "Path": "/data/packages"
+  },
+  "ConnectionStrings": {
+    "Sqlite": "Data Source=/data/packages.db"
+  },
+  "Search": {
+    "Type": "Database",
+    "IncludeMirroredPackages": false
+  },
+  "Mirror": {
+    "NuGetConfigPath": "/config/NuGet.config",
+    "DefaultCachingStrategy": "CacheOnly"
+  },
+  "PackageSources": [
+    {
+      "Name": "NuGet.org",
+      "FeedUrl": "https://api.nuget.org/v3/index.json",
+      "Type": "Upstream",
+      "CachingStrategy": "CacheOnly",
+      "IsEnabled": true
+    }
+  ]
+}
+```
+
+Use `ProxyOnly` instead of `CacheOnly` when you want zero disk growth from upstream restores (every restore streams from upstream).
+
+> **Note:** A dedicated `LightweightFeed` Docker sample is tracked in [#584](https://github.com/AvantiPoint/avantipoint.packages/issues/584). Until that sample ships, use this configuration with the standard Host image and a mounted `/data` volume. See [Hosting](hosting.md) for Docker run examples.
+
+---
+
+## Migration guide for existing deployments
+
+If you are upgrading to v4 with package origin and caching strategy support, **no configuration changes are required** to preserve current behavior:
+
+| Setting | Default | Existing behavior preserved |
+|---------|---------|----------------------------|
+| `Search.IncludeMirroredPackages` | `true` | Mirrored packages remain visible in search |
+| `PackageSource.CachingStrategy` | `IndexAndCache` | Upstream packages are cached and indexed as before |
+
+### Optional changes by scenario
+
+| If you want… | Change |
+|--------------|--------|
+| Hide upstream packages from search (commercial/private feed) | Set `Search.IncludeMirroredPackages` to `false` |
+| Restore upstream deps without search visibility or DB metadata | Set upstream `CachingStrategy` to `CacheOnly` |
+| Restore upstream deps with no local disk usage | Set upstream `CachingStrategy` to `ProxyOnly` |
+| Full enterprise mirror (current default) | Keep defaults (`IncludeMirroredPackages: true`, `IndexAndCache`) |
+
+### Migrating from legacy `Mirror` configuration
+
+The legacy `Mirror` dictionary and `AddUpstreamSource` helpers are deprecated in v4.0:
+
+1. Create equivalent `PackageSource` rows (via Host UI or database) with `Name`, `FeedUrl`, `CachingStrategy`, and credentials
+2. Or use `Mirror:NuGetConfigPath` to bootstrap sources from an existing `NuGet.config` on startup
+3. Remove the old `Mirror` section from `appsettings.json` once sources are configured
+
+Existing mirrored packages in the database retain their stored origin. New restores follow the `CachingStrategy` on each source.
+
+## See Also
+
+- [Upstream Mirrors](mirrors.md) - Caching strategies, authentication, and troubleshooting
+- [Configuration](configuration.md) - Full configuration reference
+- [Hosting](hosting.md) - Docker and production deployment

--- a/docs/docs/deployment-scenarios.md
+++ b/docs/docs/deployment-scenarios.md
@@ -5,7 +5,7 @@ sidebar_label: Deployment Scenarios
 sidebar_position: 5
 ---
 
-This guide describes common feed deployment patterns from [epic #535](https://github.com/AvantiPoint/avantipoint.packages/issues/535). Each scenario combines `PackageSources` caching strategies with `Search.IncludeMirroredPackages` to control what appears in browse/search versus what is available for restore.
+This guide describes common feed deployment patterns. Each scenario combines `PackageSources` caching strategies with `Search.IncludeMirroredPackages` to control what appears in browse/search versus what is available for restore.
 
 For strategy details and the full behavior matrix, see [Upstream Mirrors](mirrors.md#caching-strategies-packagesourcecachingstrategy).
 
@@ -179,7 +179,7 @@ This is the **default behavior** for existing deployments: upstream packages are
 
 Use `ProxyOnly` instead of `CacheOnly` when you want zero disk growth from upstream restores (every restore streams from upstream).
 
-> **Note:** A dedicated `LightweightFeed` Docker sample is tracked in [#584](https://github.com/AvantiPoint/avantipoint.packages/issues/584). Until that sample ships, use this configuration with the standard Host image and a mounted `/data` volume. See [Hosting](hosting.md) for Docker run examples.
+> **Note:** Run the standard Host image with a mounted `/data` volume for local development or CI. Point `Storage.Path` and the Sqlite connection string at paths under `/data`, keep `Search.IncludeMirroredPackages` at `false`, and set upstream sources to `CacheOnly` (or `ProxyOnly` when you want zero disk growth from upstream restores). See [Hosting](hosting.md) for Docker run examples.
 
 ---
 

--- a/docs/docs/feeds/multi-feed-ui.md
+++ b/docs/docs/feeds/multi-feed-ui.md
@@ -1,8 +1,8 @@
 # Multi-feed UI components
 
-Parent epic: [#557 — Unified Multi-Feed Platform](https://github.com/AvantiPoint/avantipoint.packages/issues/557).
+The unified multi-feed platform extends **`AvantiPoint.Packages.UI.Razor`** so hosts can expose NuGet, npm, and OCI registries from a single public origin.
 
-Today **`AvantiPoint.Packages.UI.Razor`** provides a NuGet-focused operator and consumer experience:
+Today the Razor library provides a NuGet-focused operator and consumer experience:
 
 | Component | Purpose |
 |-----------|---------|
@@ -18,7 +18,7 @@ Multi-feed hosts add **parallel npm and OCI experiences** on the same public ori
 2. **Surface-aware URLs** — components derive registry roots from `IFeedRegistry` + `IPublicBaseUrlProvider` (not hard-coded `/v3` or `/npm`).
 3. **Reuse patterns, not domain models** — mirror NuGet component structure (connection card → browse → detail) with protocol-specific services.
 4. **Optional surfaces** — navigation and pages hide when `UseNpm()` / `UseOci*` is not registered.
-5. **Align with #536** — Blazor/Razor first; React parity tracked separately.
+5. **Blazor/Razor first** — Primary UI components ship in the Razor library; a React surface is optional and maintained separately.
 
 ## npm UI (`FeedProtocol.Npm`)
 
@@ -75,9 +75,12 @@ builder.Services.AddOciRepositoryBrowseUi();
 
 Sample hosts: **OpenFeed** (reference), **Packages.Host** (production host).
 
-## Tracking issues
+## Component coverage
 
-- #599 — Phase 6 parent
-- #600 — npm UI
-- #601 — OCI UI
-- #602 — Host shell (OpenFeed integration)
+Multi-feed UI spans three areas, each mirroring the NuGet component pattern (connection card → browse → detail):
+
+| Area | Components | Registration |
+|------|------------|--------------|
+| npm UI | `NpmFeedInfo`, `NpmPackageSearch`, `NpmPackageDetail` | `AddNpmPackageBrowseUi()` |
+| OCI UI | `OciFeedInfo`, `OciRepositoryCatalog`, `OciRepositoryDetail`, `OciArtifactDetail` | `AddOciRepositoryBrowseUi()` |
+| Host shell | `MultiFeedNavigation` | Register surfaces via `IFeedRegistry`; see sample hosts below |

--- a/docs/docs/mirrors.md
+++ b/docs/docs/mirrors.md
@@ -63,7 +63,59 @@ Configure upstream sources using the `PackageSources` section in `appsettings.js
 - `Username` / `Password` / `ApiKey` – Optional authentication.
 - `IsEnabled` – Controls whether the source participates in mirroring.
 
-For advanced scenarios, you can manage `PackageSource` rows directly via the database or future admin tooling.
+For advanced scenarios, you can manage `PackageSource` rows directly via the database or the Host UI at `/Account/PackageSources`.
+
+## Caching strategies (`PackageSourceCachingStrategy`)
+
+Each upstream source has a `CachingStrategy` that controls how packages from that source are stored, indexed, and exposed in search. This works together with [`Search.IncludeMirroredPackages`](configuration.md#search-and-discovery) to determine what clients see when browsing the feed.
+
+| Strategy | Package binary on disk | Database metadata | Search index | Package origin |
+|----------|------------------------|-------------------|--------------|----------------|
+| `IndexAndCache` (default) | Yes | Yes | Yes | `Mirrored` |
+| `CacheOnly` | Yes | No | No | `Cached` (storage-only) |
+| `ProxyOnly` | No | No | No | *(not stored locally)* |
+
+### `IndexAndCache`
+
+The default behavior. When a client restores a package that is not already local:
+
+1. Download the package from the upstream source
+2. Store the `.nupkg` in configured storage (file system, Azure Blob, S3, etc.)
+3. Persist package metadata in the database with origin `Mirrored`
+4. Index the package for search and registration discovery (subject to `Search.IncludeMirroredPackages`)
+
+Subsequent restores are served from local storage. Packages remain available even if the upstream source is temporarily unavailable.
+
+### `CacheOnly`
+
+Use when you want faster repeat restores without growing search results or database metadata:
+
+1. Download and store the package binary in storage
+2. **Skip** database persistence and search indexing
+
+Packages cached with this strategy are never returned by search, autocomplete, or registration discovery—regardless of `Search.IncludeMirroredPackages`. Clients can still restore packages they request by id and version.
+
+### `ProxyOnly`
+
+Use when you want upstream packages available for restore with **minimal disk usage**:
+
+1. Stream the package from upstream on each restore request
+2. Do **not** write to local storage, the database, or the search index
+
+`ProxyOnly` is the built-in alternative to custom proxy implementations. There is no local cache; upstream availability and latency apply on every restore.
+
+### Strategy × search × disk usage
+
+How each strategy interacts with [`Search.IncludeMirroredPackages`](configuration.md#search-and-discovery):
+
+| Caching strategy | `IncludeMirroredPackages: true` | `IncludeMirroredPackages: false` | Disk usage |
+|------------------|--------------------------------|----------------------------------|------------|
+| `IndexAndCache` | Appears in search (`Mirrored`) | Hidden from search; restore works | Grows with every unique restore |
+| `CacheOnly` | Never appears in search | Never appears in search | Grows with every unique restore |
+| `ProxyOnly` | Never appears in search | Never appears in search | None (streamed from upstream) |
+| Published (direct push) | Appears in search | Appears in search | Grows with each push |
+
+For deployment patterns that combine these settings, see [Deployment Scenarios](deployment-scenarios.md).
 
 ### NuGet.config (runtime-only sources)
 
@@ -232,23 +284,60 @@ You can configure as many upstream sources as you need:
 
 When a package is requested, AvantiPoint Packages will search sources in the order they are defined (though this order is not guaranteed, so don't rely on it for priority).
 
-## Caching Behavior
+## Caching behavior by strategy
 
-Once a package is downloaded from an upstream source:
+What happens after a client restores a package from upstream depends on the source's `CachingStrategy`:
 
-1. It's stored in your local storage (file system, Azure Blob, or S3)
-2. It's indexed in your local database
-3. Future requests are served from local storage (much faster)
-4. The package is retained even if removed from the upstream source
+**`IndexAndCache`** (default):
 
-This provides:
-- **Performance** - No need to contact upstream sources for cached packages
-- **Reliability** - Your feed continues working even if upstream sources are unavailable
-- **Offline capability** - Cached packages are available without internet access
+1. Package binary is stored in local storage
+2. Metadata is persisted in the database with origin `Mirrored`
+3. The package is indexed for search (unless filtered by `Search.IncludeMirroredPackages`)
+4. Future restores are served from local storage
 
-## Disabling Caching
+**`CacheOnly`**:
 
-If you want to always proxy without caching (not recommended), you would need to customize the implementation. The default behavior is to cache all packages.
+1. Package binary is stored in local storage
+2. Database metadata and search indexing are skipped
+3. Future restores are served from local storage
+4. The package never appears in browse/search
+
+**`ProxyOnly`**:
+
+1. Package is streamed from upstream for that request only
+2. Nothing is written to storage, the database, or the search index
+3. Each restore may contact the upstream source again
+
+For `IndexAndCache` and `CacheOnly`, locally stored packages remain available even if the upstream source is temporarily unavailable.
+
+## Proxy-only upstream sources
+
+To always proxy without caching, set `CachingStrategy` to `ProxyOnly` on the upstream source. No custom implementation is required.
+
+```json
+{
+  "PackageSources": [
+    {
+      "Name": "NuGet.org",
+      "FeedUrl": "https://api.nuget.org/v3/index.json",
+      "Type": "Upstream",
+      "CachingStrategy": "ProxyOnly",
+      "IsEnabled": true
+    }
+  ]
+}
+```
+
+You can also apply `ProxyOnly` to all sources loaded from `NuGet.config` by setting `Mirror:DefaultCachingStrategy`:
+
+```json
+{
+  "Mirror": {
+    "NuGetConfigPath": "/config/NuGet.config",
+    "DefaultCachingStrategy": "ProxyOnly"
+  }
+}
+```
 
 ## Security Considerations
 
@@ -371,6 +460,7 @@ Or use a script to bulk-import common packages.
 
 ## See Also
 
+- [Deployment Scenarios](deployment-scenarios.md) - Commercial, enterprise mirror, and lightweight dev/Docker patterns
 - [Configuration](configuration.md) - Overall configuration guide
 - [Storage](storage/index.md) - Configure package storage
 - [Getting Started](getting-started.md) - Quick start guide

--- a/docs/docs/ui-components.md
+++ b/docs/docs/ui-components.md
@@ -712,7 +712,8 @@ If you're migrating from BaGet's built-in UI (or [Bagetter](https://github.com/b
 The UI component library is open source and contributions are welcome:
 
 - **Repository:** [github.com/AvantiPoint/avantipoint.packages](https://github.com/AvantiPoint/avantipoint.packages)
-- **Pull Requests:** Submit PRs for bug fixes or new features via the repository
+- **Issues:** Report bugs or request features via [GitHub Issues](https://github.com/AvantiPoint/avantipoint.packages/issues)
+- **Pull Requests:** Submit PRs for bug fixes or new features
 
 ## License
 

--- a/docs/docs/ui-components.md
+++ b/docs/docs/ui-components.md
@@ -712,8 +712,7 @@ If you're migrating from BaGet's built-in UI (or [Bagetter](https://github.com/b
 The UI component library is open source and contributions are welcome:
 
 - **Repository:** [github.com/AvantiPoint/avantipoint.packages](https://github.com/AvantiPoint/avantipoint.packages)
-- **Issues:** Report bugs or request features via GitHub Issues
-- **Pull Requests:** Submit PRs for bug fixes or new features
+- **Pull Requests:** Submit PRs for bug fixes or new features via the repository
 
 ## License
 

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -11,6 +11,7 @@ const sidebars: SidebarsConfig = {
             items: [
                 'registration',
                 'configuration',
+                'deployment-scenarios',
                 'mirrors',
             ],
         },

--- a/samples/IntegrationTestApi/appsettings.json
+++ b/samples/IntegrationTestApi/appsettings.json
@@ -16,5 +16,23 @@
   },
   "Search": {
     "Type": "Database"
+    // "IncludeMirroredPackages": true   // default; set false to hide mirrored packages from search
   }
+
+  // PackageSources (v4 upstream mirror model) — configure via Host UI or database seeding.
+  // See docs/docs/deployment-scenarios.md for commercial, enterprise, and lightweight patterns.
+  //
+  // "PackageSources": [
+  //   {
+  //     "Name": "NuGet.org",
+  //     "FeedUrl": "https://api.nuget.org/v3/index.json",
+  //     "Type": "Upstream",
+  //     "CachingStrategy": "IndexAndCache",
+  //     "IsEnabled": true
+  //   }
+  // ],
+  // "Search": {
+  //   "Type": "Database",
+  //   "IncludeMirroredPackages": false
+  // }
 }

--- a/samples/OpenFeed/appsettings.json
+++ b/samples/OpenFeed/appsettings.json
@@ -59,6 +59,44 @@
   //  "Container": "my-container"
   //}
 
+  // PackageSources (v4 upstream mirror model) — see docs/docs/mirrors.md and deployment-scenarios.md.
+  // CachingStrategy: IndexAndCache | CacheOnly | ProxyOnly
+  // Combine with Search.IncludeMirroredPackages to control search visibility.
+  //
+  // "PackageSources": [
+  //   {
+  //     "Name": "NuGet.org",
+  //     "FeedUrl": "https://api.nuget.org/v3/index.json",
+  //     "Type": "Upstream",
+  //     "CachingStrategy": "IndexAndCache",
+  //     "IsEnabled": true
+  //   },
+  //   {
+  //     "Name": "dotnet10",
+  //     "FeedUrl": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json",
+  //     "Type": "Upstream",
+  //     "CachingStrategy": "CacheOnly",
+  //     "IsEnabled": true
+  //   },
+  //   {
+  //     "Name": "Telerik",
+  //     "FeedUrl": "https://nuget.telerik.com/nuget",
+  //     "Type": "Upstream",
+  //     "CachingStrategy": "ProxyOnly",
+  //     "Username": "{your username}",
+  //     "Password": "{your password}",
+  //     "IsEnabled": true
+  //   }
+  // ],
+  //
+  // "Search": {
+  //   "Type": "Database",
+  //   "IncludeMirroredPackages": false
+  // }
+  //
+  // LightweightFeed Docker sample (CacheOnly + local cache): see issue #584
+
+  // Legacy Mirror config (deprecated in v4):
   //"Mirror": {
   //  "NuGet.org": {
   //    "FeedUrl": "https://api.nuget.org/v3/index.json"

--- a/samples/OpenFeed/appsettings.json
+++ b/samples/OpenFeed/appsettings.json
@@ -94,7 +94,7 @@
   //   "IncludeMirroredPackages": false
   // }
   //
-  // LightweightFeed Docker sample (CacheOnly + local cache): see issue #584
+  // Lightweight dev/Docker: CacheOnly upstream, IncludeMirroredPackages false, Storage.Path and Sqlite under /data (see deployment-scenarios.md)
 
   // Legacy Mirror config (deprecated in v4):
   //"Mirror": {

--- a/tests/AvantiPoint.Packages.Integration.Tests/AvantiPoint.Packages.Integration.Tests.csproj
+++ b/tests/AvantiPoint.Packages.Integration.Tests/AvantiPoint.Packages.Integration.Tests.csproj
@@ -33,6 +33,9 @@
     <ProjectReference Include="..\..\src\AvantiPoint.Packages.Core\AvantiPoint.Packages.Core.csproj" />
     <ProjectReference Include="..\..\src\AvantiPoint.Packages.Hosting\AvantiPoint.Packages.Hosting.csproj" />
     <ProjectReference Include="..\..\samples\IntegrationTestApi\IntegrationTestApi.csproj" />
+    <ProjectReference Include="..\..\samples\OpenFeed\OpenFeed.csproj" />
+    <ProjectReference Include="..\..\src\AvantiPoint.Packages.Protocol\AvantiPoint.Packages.Protocol.csproj" />
+    <ProjectReference Include="..\..\src\AvantiPoint.Feed.Platform\AvantiPoint.Feed.Platform.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/AvantiPoint.Packages.Integration.Tests/NuGetOrgCachingIntegrationTests.cs
+++ b/tests/AvantiPoint.Packages.Integration.Tests/NuGetOrgCachingIntegrationTests.cs
@@ -1,0 +1,73 @@
+using AvantiPoint.Packages.Core;
+using AvantiPoint.Packages.Integration.Tests.TestInfrastructure;
+namespace AvantiPoint.Packages.Integration.Tests;
+
+/// <summary>
+/// Optional live-upstream checks against nuget.org (skipped when outbound network is unavailable).
+/// </summary>
+public sealed class NuGetOrgCachingIntegrationTests
+{
+    private const string PackageId = "Newtonsoft.Json";
+    private const string Version = "13.0.3";
+
+    [ExternalNetworkFact]
+    public async Task NuGetOrg_IndexAndCache_PersistsDatabaseAndStorage()
+    {
+        await using var feed = await FeedUnderTestHost.StartAsync(new FeedUnderTestOptions
+        {
+            UpstreamServiceIndexUrl = ExternalNetworkFactAttribute.NuGetOrgServiceIndex,
+            UpstreamSourceName = "nuget.org",
+            CachingStrategy = PackageSourceCachingStrategy.IndexAndCache,
+        });
+
+        var download = await feed.Client.GetAsync(
+            TestPackageBuilder.GetPackageDownloadPath(PackageId, Version),
+            TestContext.Current.CancellationToken);
+        download.EnsureSuccessStatusCode();
+
+        var package = await feed.FindPackageAsync(PackageId, Version);
+        Assert.NotNull(package);
+        Assert.Equal(PackageOrigin.Mirrored, package.Origin);
+        Assert.True(FeedUnderTestHost.CountPackageFiles(feed.StoragePath) >= 1);
+    }
+
+    [ExternalNetworkFact]
+    public async Task NuGetOrg_CacheOnly_PersistsStorageOnly()
+    {
+        await using var feed = await FeedUnderTestHost.StartAsync(new FeedUnderTestOptions
+        {
+            UpstreamServiceIndexUrl = ExternalNetworkFactAttribute.NuGetOrgServiceIndex,
+            UpstreamSourceName = "nuget.org",
+            CachingStrategy = PackageSourceCachingStrategy.CacheOnly,
+        });
+
+        var download = await feed.Client.GetAsync(
+            TestPackageBuilder.GetPackageDownloadPath(PackageId, Version),
+            TestContext.Current.CancellationToken);
+        download.EnsureSuccessStatusCode();
+
+        Assert.Null(await feed.FindPackageAsync(PackageId, Version));
+        Assert.True(FeedUnderTestHost.CountPackageFiles(feed.StoragePath) >= 1);
+    }
+
+    [ExternalNetworkFact]
+    public async Task NuGetOrg_ProxyOnly_DoesNotPersistLocally()
+    {
+        await using var feed = await FeedUnderTestHost.StartAsync(new FeedUnderTestOptions
+        {
+            UpstreamServiceIndexUrl = ExternalNetworkFactAttribute.NuGetOrgServiceIndex,
+            UpstreamSourceName = "nuget.org",
+            CachingStrategy = PackageSourceCachingStrategy.ProxyOnly,
+        });
+
+        var filesBefore = FeedUnderTestHost.CountPackageFiles(feed.StoragePath);
+
+        var download = await feed.Client.GetAsync(
+            TestPackageBuilder.GetPackageDownloadPath(PackageId, Version),
+            TestContext.Current.CancellationToken);
+        download.EnsureSuccessStatusCode();
+
+        Assert.Null(await feed.FindPackageAsync(PackageId, Version));
+        Assert.Equal(filesBefore, FeedUnderTestHost.CountPackageFiles(feed.StoragePath));
+    }
+}

--- a/tests/AvantiPoint.Packages.Integration.Tests/PackageOriginIntegrationTests.cs
+++ b/tests/AvantiPoint.Packages.Integration.Tests/PackageOriginIntegrationTests.cs
@@ -1,0 +1,151 @@
+using System.Net.Http.Json;
+using AvantiPoint.Packages.Core;
+using AvantiPoint.Packages.Integration.Tests.TestInfrastructure;
+using AvantiPoint.Packages.Protocol.Models;
+namespace AvantiPoint.Packages.Integration.Tests;
+
+/// <summary>
+/// End-to-end origin and caching-strategy coverage using OpenFeed as upstream (issue #581).
+/// </summary>
+public sealed class PackageOriginIntegrationTests
+{
+    private const string UpstreamPackageId = "OriginTest.Upstream";
+    private const string PublishedPackageId = "OriginTest.Published";
+    private const string Version = "1.0.0";
+
+    [Fact]
+    public async Task Publish_ToFeedUnderTest_SetsOriginPublished()
+    {
+        await using var feed = await FeedUnderTestHost.StartAsync(new FeedUnderTestOptions());
+
+        await TestPackageBuilder.PublishAsync(feed.Client, PublishedPackageId, Version);
+
+        var package = await feed.FindPackageAsync(PublishedPackageId, Version);
+        Assert.NotNull(package);
+        Assert.Equal(PackageOrigin.Published, package.Origin);
+        Assert.True(FeedUnderTestHost.CountPackageFiles(feed.StoragePath) >= 1);
+    }
+
+    [Fact]
+    public async Task Mirror_IndexAndCache_SetsOriginMirrored_AndAppearsInSearch()
+    {
+        await using var upstream = await UpstreamOpenFeedHost.StartAsync();
+        await upstream.SeedPackageAsync(UpstreamPackageId, Version);
+
+        await using var feed = await FeedUnderTestHost.StartAsync(new FeedUnderTestOptions
+        {
+            UpstreamServiceIndexUrl = upstream.ServiceIndexUrl,
+            CachingStrategy = PackageSourceCachingStrategy.IndexAndCache,
+            IncludeMirroredPackages = true,
+        });
+
+        var download = await feed.Client.GetAsync(
+            TestPackageBuilder.GetPackageDownloadPath(UpstreamPackageId, Version),
+            TestContext.Current.CancellationToken);
+        download.EnsureSuccessStatusCode();
+
+        var package = await feed.FindPackageAsync(UpstreamPackageId, Version);
+        Assert.NotNull(package);
+        Assert.Equal(PackageOrigin.Mirrored, package.Origin);
+        Assert.True(FeedUnderTestHost.CountPackageFiles(feed.StoragePath) >= 1);
+
+        var search = await feed.Client.GetAsync(
+            $"/v3/search?q={UpstreamPackageId}&take=10&prerelease=true",
+            TestContext.Current.CancellationToken);
+        search.EnsureSuccessStatusCode();
+        var searchResponse = await search.Content.ReadFromJsonAsync<SearchResponse>(TestContext.Current.CancellationToken);
+        Assert.NotNull(searchResponse);
+        Assert.Contains(searchResponse.Data, p => p.PackageId == UpstreamPackageId);
+    }
+
+    [Fact]
+    public async Task Search_IncludeMirroredPackagesFalse_ExcludesMirrored_FromHttpAndDbDiscovery()
+    {
+        await using var upstream = await UpstreamOpenFeedHost.StartAsync();
+        await upstream.SeedPackageAsync(UpstreamPackageId, Version);
+
+        await using var feed = await FeedUnderTestHost.StartAsync(new FeedUnderTestOptions
+        {
+            UpstreamServiceIndexUrl = upstream.ServiceIndexUrl,
+            CachingStrategy = PackageSourceCachingStrategy.IndexAndCache,
+            IncludeMirroredPackages = false,
+        });
+
+        await TestPackageBuilder.PublishAsync(feed.Client, PublishedPackageId, Version);
+
+        var download = await feed.Client.GetAsync(
+            TestPackageBuilder.GetPackageDownloadPath(UpstreamPackageId, Version),
+            TestContext.Current.CancellationToken);
+        download.EnsureSuccessStatusCode();
+
+        var mirrored = await feed.FindPackageAsync(UpstreamPackageId, Version);
+        Assert.NotNull(mirrored);
+        Assert.Equal(PackageOrigin.Mirrored, mirrored.Origin);
+
+        var search = await feed.Client.GetAsync(
+            "/v3/search?q=OriginTest&take=20&prerelease=true",
+            TestContext.Current.CancellationToken);
+        search.EnsureSuccessStatusCode();
+        var searchResponse = await search.Content.ReadFromJsonAsync<SearchResponse>(TestContext.Current.CancellationToken);
+        Assert.NotNull(searchResponse);
+        Assert.Contains(searchResponse.Data, p => p.PackageId == PublishedPackageId);
+        Assert.DoesNotContain(searchResponse.Data, p => p.PackageId == UpstreamPackageId);
+    }
+
+    [Fact]
+    public async Task Mirror_CacheOnly_PersistsContent_SkipsDatabase_AndExcludesFromSearch()
+    {
+        await using var upstream = await UpstreamOpenFeedHost.StartAsync();
+        await upstream.SeedPackageAsync(UpstreamPackageId, Version);
+
+        await using var feed = await FeedUnderTestHost.StartAsync(new FeedUnderTestOptions
+        {
+            UpstreamServiceIndexUrl = upstream.ServiceIndexUrl,
+            CachingStrategy = PackageSourceCachingStrategy.CacheOnly,
+            IncludeMirroredPackages = true,
+        });
+
+        var download = await feed.Client.GetAsync(
+            TestPackageBuilder.GetPackageDownloadPath(UpstreamPackageId, Version),
+            TestContext.Current.CancellationToken);
+        download.EnsureSuccessStatusCode();
+        Assert.True(download.Content.Headers.ContentLength > 0);
+
+        var package = await feed.FindPackageAsync(UpstreamPackageId, Version);
+        Assert.Null(package);
+        Assert.True(FeedUnderTestHost.CountPackageFiles(feed.StoragePath) >= 1);
+
+        var search = await feed.Client.GetAsync(
+            $"/v3/search?q={UpstreamPackageId}&take=10&prerelease=true",
+            TestContext.Current.CancellationToken);
+        search.EnsureSuccessStatusCode();
+        var searchResponse = await search.Content.ReadFromJsonAsync<SearchResponse>(TestContext.Current.CancellationToken);
+        Assert.NotNull(searchResponse);
+        Assert.DoesNotContain(searchResponse.Data, p => p.PackageId == UpstreamPackageId);
+    }
+
+    [Fact]
+    public async Task Mirror_ProxyOnly_DoesNotPersistContent_OrDatabase()
+    {
+        await using var upstream = await UpstreamOpenFeedHost.StartAsync();
+        await upstream.SeedPackageAsync(UpstreamPackageId, Version);
+
+        await using var feed = await FeedUnderTestHost.StartAsync(new FeedUnderTestOptions
+        {
+            UpstreamServiceIndexUrl = upstream.ServiceIndexUrl,
+            CachingStrategy = PackageSourceCachingStrategy.ProxyOnly,
+        });
+
+        var filesBefore = FeedUnderTestHost.CountPackageFiles(feed.StoragePath);
+
+        var download = await feed.Client.GetAsync(
+            TestPackageBuilder.GetPackageDownloadPath(UpstreamPackageId, Version),
+            TestContext.Current.CancellationToken);
+        download.EnsureSuccessStatusCode();
+        Assert.True(download.Content.Headers.ContentLength > 0);
+
+        var package = await feed.FindPackageAsync(UpstreamPackageId, Version);
+        Assert.Null(package);
+        Assert.Equal(filesBefore, FeedUnderTestHost.CountPackageFiles(feed.StoragePath));
+    }
+}

--- a/tests/AvantiPoint.Packages.Integration.Tests/PackageOriginIntegrationTests.cs
+++ b/tests/AvantiPoint.Packages.Integration.Tests/PackageOriginIntegrationTests.cs
@@ -5,7 +5,7 @@ using AvantiPoint.Packages.Protocol.Models;
 namespace AvantiPoint.Packages.Integration.Tests;
 
 /// <summary>
-/// End-to-end origin and caching-strategy coverage using OpenFeed as upstream (issue #581).
+/// End-to-end origin and caching-strategy coverage using OpenFeed as upstream.
 /// </summary>
 public sealed class PackageOriginIntegrationTests
 {

--- a/tests/AvantiPoint.Packages.Integration.Tests/TestInfrastructure/ExternalNetworkFactAttribute.cs
+++ b/tests/AvantiPoint.Packages.Integration.Tests/TestInfrastructure/ExternalNetworkFactAttribute.cs
@@ -1,0 +1,62 @@
+using System.Net;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace AvantiPoint.Packages.Integration.Tests.TestInfrastructure;
+
+/// <summary>
+/// Runs only when outbound HTTPS to NuGet.org succeeds (optional live-upstream tests).
+/// </summary>
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+public sealed class ExternalNetworkFactAttribute : FactAttribute
+{
+    public const string NuGetOrgServiceIndex = "https://api.nuget.org/v3/index.json";
+
+    public ExternalNetworkFactAttribute(
+        [CallerFilePath] string? sourceFilePath = null,
+        [CallerLineNumber] int sourceLineNumber = -1)
+        : base(sourceFilePath, sourceLineNumber)
+    {
+        if (!ExternalNetworkAvailability.CanReachNuGetOrg)
+        {
+            Skip = ExternalNetworkAvailability.SkipReason
+                ?? "Outbound network access to NuGet.org is not available.";
+        }
+    }
+}
+
+internal static class ExternalNetworkAvailability
+{
+    private static readonly Lazy<bool> _canReachNuGetOrg = new(CheckNuGetOrg);
+    private static readonly Lazy<string?> _skipReason = new(GetSkipReason);
+
+    public static bool CanReachNuGetOrg => _canReachNuGetOrg.Value;
+
+    public static string? SkipReason => _skipReason.Value;
+
+    private static bool CheckNuGetOrg()
+    {
+        try
+        {
+            using var handler = new HttpClientHandler
+            {
+                AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
+            };
+            using var client = new HttpClient(handler)
+            {
+                Timeout = TimeSpan.FromSeconds(10),
+            };
+
+            using var request = new HttpRequestMessage(HttpMethod.Get, ExternalNetworkFactAttribute.NuGetOrgServiceIndex);
+            using var response = client.Send(request);
+            return response.IsSuccessStatusCode;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static string? GetSkipReason() =>
+        CanReachNuGetOrg ? null : "NuGet.org is not reachable from this environment.";
+}

--- a/tests/AvantiPoint.Packages.Integration.Tests/TestInfrastructure/FeedUnderTestHost.cs
+++ b/tests/AvantiPoint.Packages.Integration.Tests/TestInfrastructure/FeedUnderTestHost.cs
@@ -1,0 +1,206 @@
+using System.Net;
+using System.Net.Sockets;
+using AvantiPoint.Feed.Platform.Extensions;
+using AvantiPoint.Packages;
+using AvantiPoint.Packages.Core;
+using AvantiPoint.Packages.Hosting;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.EntityFrameworkCore;
+
+namespace AvantiPoint.Packages.Integration.Tests.TestInfrastructure;
+
+/// <summary>
+/// Kestrel-hosted feed under test (IntegrationTestApi stack) with optional upstream <see cref="PackageSource"/>.
+/// </summary>
+public sealed class FeedUnderTestHost : IAsyncDisposable
+{
+    private readonly WebApplication _app;
+    private readonly string _tempDirectory;
+    private bool _disposed;
+
+    private FeedUnderTestHost(
+        WebApplication app,
+        string tempDirectory,
+        HttpClient client,
+        Uri baseAddress,
+        string storagePath,
+        string dbPath)
+    {
+        _app = app;
+        _tempDirectory = tempDirectory;
+        Client = client;
+        BaseAddress = baseAddress;
+        StoragePath = storagePath;
+        DbPath = dbPath;
+    }
+
+    public HttpClient Client { get; }
+
+    public Uri BaseAddress { get; }
+
+    public string StoragePath { get; }
+
+    public string DbPath { get; }
+
+    public IServiceProvider Services => _app.Services;
+
+    public static async Task<FeedUnderTestHost> StartAsync(
+        FeedUnderTestOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        var tempDirectory = Path.Combine(Path.GetTempPath(), $"feed-under-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDirectory);
+
+        var dbPath = Path.Combine(tempDirectory, "feed.db");
+        var packagesPath = Path.Combine(tempDirectory, "packages");
+        Directory.CreateDirectory(packagesPath);
+
+        var port = GetFreePort();
+
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+        {
+            EnvironmentName = Environments.Development,
+        });
+
+        var settings = new Dictionary<string, string?>
+        {
+            ["ApiKey"] = options.ApiKey,
+            ["Feed:Authentication:ApiKey"] = options.ApiKey,
+            ["Feed:Authentication:AllowAnonymousPull"] = "true",
+            ["PackageDeletionBehavior"] = "HardDelete",
+            ["AllowPackageOverwrites"] = "true",
+            ["IsReadOnlyMode"] = "false",
+            ["EnablePackageMetadataBackfill"] = "false",
+            ["Database:Type"] = "Sqlite",
+            ["Search:Type"] = "Database",
+            ["Search:IncludeMirroredPackages"] = options.IncludeMirroredPackages ? "true" : "false",
+            ["Storage:Type"] = "FileSystem",
+            ["Storage:Path"] = packagesPath,
+            ["ConnectionStrings:Sqlite"] = $"Data Source={dbPath}",
+            ["Signing:Provider"] = null,
+            ["Logging:LogLevel:Default"] = "Warning",
+            ["Logging:LogLevel:Microsoft"] = "Warning",
+        };
+
+        builder.Configuration.AddInMemoryCollection(settings);
+        builder.WebHost.UseKestrel(o => o.Listen(IPAddress.Loopback, port));
+
+        builder.Services.AddNuGetPackageApi(o =>
+        {
+            o.AddFileStorage();
+            o.AddSqliteDatabase("Sqlite");
+        });
+
+        var feed = builder.AddAvantiPointFeed(builder.Configuration.GetSection("Feed"));
+        feed.UseNuGet();
+
+        var app = builder.Build();
+        app.UseAvantiPointFeedPlatform();
+        app.UseRouting();
+        app.MapNuGetApiRoutes();
+
+        using (var scope = app.Services.CreateScope())
+        {
+            var context = scope.ServiceProvider.GetRequiredService<IContext>();
+            await context.RunMigrationsAsync(cancellationToken);
+
+            if (options.UpstreamServiceIndexUrl is not null)
+            {
+                context.PackageSources.Add(new PackageSource
+                {
+                    Name = options.UpstreamSourceName ?? "test-upstream",
+                    FeedUrl = options.UpstreamServiceIndexUrl,
+                    Type = PackageSourceType.Upstream,
+                    CachingStrategy = options.CachingStrategy,
+                    IsEnabled = true,
+                });
+                await context.SaveChangesAsync(cancellationToken);
+            }
+        }
+
+        await app.StartAsync(cancellationToken);
+
+        var server = app.Services.GetRequiredService<IServer>();
+        var address = server.Features.Get<IServerAddressesFeature>()?.Addresses.FirstOrDefault()
+            ?? throw new InvalidOperationException("Failed to determine feed-under-test server address.");
+
+        var baseAddress = new Uri(address);
+        var handler = new HttpClientHandler
+        {
+            AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
+        };
+        var client = new HttpClient(handler) { BaseAddress = baseAddress };
+
+        return new FeedUnderTestHost(app, tempDirectory, client, baseAddress, packagesPath, dbPath);
+    }
+
+    public async Task<Package?> FindPackageAsync(string id, string version, CancellationToken cancellationToken = default)
+    {
+        using var scope = Services.CreateScope();
+        var packages = scope.ServiceProvider.GetRequiredService<IPackageService>();
+        return await packages.FindOrNullAsync(
+            id,
+            NuGet.Versioning.NuGetVersion.Parse(version),
+            includeUnlisted: true,
+            cancellationToken);
+    }
+
+    public static int CountPackageFiles(string storagePath) =>
+        Directory.Exists(storagePath)
+            ? Directory.GetFiles(storagePath, "*.nupkg", SearchOption.AllDirectories).Length
+            : 0;
+
+    private static int GetFreePort()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        Client.Dispose();
+        await _app.StopAsync();
+        await _app.DisposeAsync();
+
+        try
+        {
+            if (Directory.Exists(_tempDirectory))
+            {
+                Directory.Delete(_tempDirectory, recursive: true);
+            }
+        }
+        catch
+        {
+            // Best effort cleanup
+        }
+    }
+}
+
+public sealed class FeedUnderTestOptions
+{
+    public string ApiKey { get; init; } = TestPackageBuilder.DefaultApiKey;
+
+    public bool IncludeMirroredPackages { get; init; } = true;
+
+    public string? UpstreamServiceIndexUrl { get; init; }
+
+    public string? UpstreamSourceName { get; init; }
+
+    public PackageSourceCachingStrategy CachingStrategy { get; init; } =
+        PackageSourceCachingStrategy.IndexAndCache;
+}

--- a/tests/AvantiPoint.Packages.Integration.Tests/TestInfrastructure/README.md
+++ b/tests/AvantiPoint.Packages.Integration.Tests/TestInfrastructure/README.md
@@ -1,6 +1,6 @@
 # Two-host mirror integration tests
 
-Issue [#581](https://github.com/AvantiPoint/avantipoint.packages/issues/581) validates package **origin** and **caching strategy** behavior end-to-end.
+These tests validate package **origin** and **caching strategy** behavior end-to-end.
 
 ## Topology
 

--- a/tests/AvantiPoint.Packages.Integration.Tests/TestInfrastructure/README.md
+++ b/tests/AvantiPoint.Packages.Integration.Tests/TestInfrastructure/README.md
@@ -1,0 +1,32 @@
+# Two-host mirror integration tests
+
+Issue [#581](https://github.com/AvantiPoint/avantipoint.packages/issues/581) validates package **origin** and **caching strategy** behavior end-to-end.
+
+## Topology
+
+```text
+  ┌─────────────────────────┐         HTTP (loopback)        ┌──────────────────────────┐
+  │  UpstreamOpenFeedHost   │  ◄───────────────────────────  │   FeedUnderTestHost      │
+  │  (OpenFeed sample stack)│                                │  (IntegrationTestApi)    │
+  │  Kestrel + Sqlite + FS  │                                │  + PackageSource row     │
+  └─────────────────────────┘                                └──────────────────────────┘
+```
+
+1. **Host A (upstream)** — `UpstreamOpenFeedHost` starts the same NuGet API stack as the [OpenFeed](../../../samples/OpenFeed) sample on a real TCP port (`127.0.0.1`). Packages are published with `TestPackageBuilder` so `.nupkg` content exists on disk.
+
+2. **Host B (feed under test)** — `FeedUnderTestHost` starts the minimal `IntegrationTestApi` host, seeds a `PackageSource` pointing at Host A’s `/v3/index.json`, and configures `Search.IncludeMirroredPackages` / `CachingStrategy` per test.
+
+`MirrorService` creates its own `HttpClient` instances (not `WebApplicationFactory`’s in-memory server), so both hosts must use **Kestrel on loopback** — the same pattern as `FeedTestServerHost` in registry tests.
+
+## Test categories
+
+| Tests | Attribute | Upstream |
+|-------|-----------|----------|
+| `PackageOriginIntegrationTests` | `[Fact]` | OpenFeed host (CI-safe) |
+| `NuGetOrgCachingIntegrationTests` | `[ExternalNetworkFact]` | nuget.org (skipped when offline) |
+
+## Assertions
+
+- **Database** — `FeedUnderTestHost.FindPackageAsync` / `IContext.Packages`
+- **Filesystem** — `*.nupkg` count under `StoragePath`
+- **HTTP search** — `GET /v3/search?q=...`

--- a/tests/AvantiPoint.Packages.Integration.Tests/TestInfrastructure/TestPackageBuilder.cs
+++ b/tests/AvantiPoint.Packages.Integration.Tests/TestInfrastructure/TestPackageBuilder.cs
@@ -1,0 +1,78 @@
+using System.Net.Http.Headers;
+using NuGet.Packaging;
+using NuGet.Versioning;
+
+namespace AvantiPoint.Packages.Integration.Tests.TestInfrastructure;
+
+/// <summary>
+/// Creates and uploads in-memory .nupkg files to a feed over HTTP.
+/// </summary>
+internal static class TestPackageBuilder
+{
+    public const string DefaultApiKey = "integration-test-key";
+
+    public static byte[] CreatePackage(string packageId, string version, string? description = null)
+    {
+        description ??= $"Test package {packageId} {version}";
+
+        var builder = new PackageBuilder
+        {
+            Id = packageId,
+            Version = NuGetVersion.Parse(version),
+            Description = description,
+        };
+        builder.Authors.Add("Integration Test");
+
+        var dummyFile = new PhysicalPackageFile
+        {
+            SourcePath = CreateTempFile(),
+            TargetPath = "lib/netstandard2.0/_.dll",
+        };
+        builder.Files.Add(dummyFile);
+
+        using var stream = new MemoryStream();
+        builder.Save(stream);
+
+        try
+        {
+            File.Delete(dummyFile.SourcePath);
+        }
+        catch
+        {
+            // Best effort cleanup
+        }
+
+        return stream.ToArray();
+    }
+
+    public static async Task PublishAsync(
+        HttpClient client,
+        string packageId,
+        string version,
+        string apiKey = DefaultApiKey,
+        CancellationToken cancellationToken = default)
+    {
+        var bytes = CreatePackage(packageId, version);
+        using var content = new ByteArrayContent(bytes);
+        content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+
+        using var request = new HttpRequestMessage(HttpMethod.Put, "/api/v2/package")
+        {
+            Content = content,
+        };
+        request.Headers.Add("X-NuGet-ApiKey", apiKey);
+
+        var response = await client.SendAsync(request, cancellationToken);
+        response.EnsureSuccessStatusCode();
+    }
+
+    public static string GetPackageDownloadPath(string packageId, string version) =>
+        $"/v3/package/{packageId.ToLowerInvariant()}/{version}/{packageId.ToLowerInvariant()}.{version}.nupkg";
+
+    private static string CreateTempFile()
+    {
+        var tempFile = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.dll");
+        File.WriteAllText(tempFile, "dummy content");
+        return tempFile;
+    }
+}

--- a/tests/AvantiPoint.Packages.Integration.Tests/TestInfrastructure/UpstreamOpenFeedHost.cs
+++ b/tests/AvantiPoint.Packages.Integration.Tests/TestInfrastructure/UpstreamOpenFeedHost.cs
@@ -1,0 +1,158 @@
+using System.Net;
+using System.Net.Sockets;
+using AvantiPoint.Feed.Platform.Extensions;
+using AvantiPoint.Packages;
+using AvantiPoint.Packages.Core;
+using AvantiPoint.Packages.Hosting;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace AvantiPoint.Packages.Integration.Tests.TestInfrastructure;
+
+/// <summary>
+/// Kestrel-hosted upstream feed using the same OpenFeed sample stack (NuGet API + file storage + Sqlite).
+/// Listens on loopback so downstream feeds can mirror via real HTTP (required by <see cref="MirrorService"/>).
+/// </summary>
+public sealed class UpstreamOpenFeedHost : IAsyncDisposable
+{
+    private readonly WebApplication _app;
+    private readonly string _tempDirectory;
+    private bool _disposed;
+
+    private UpstreamOpenFeedHost(WebApplication app, string tempDirectory, HttpClient client, Uri baseAddress)
+    {
+        _app = app;
+        _tempDirectory = tempDirectory;
+        Client = client;
+        BaseAddress = baseAddress;
+        StoragePath = Path.Combine(tempDirectory, "packages");
+    }
+
+    public HttpClient Client { get; }
+
+    public Uri BaseAddress { get; }
+
+    public string ServiceIndexUrl => new Uri(BaseAddress, "/v3/index.json").ToString();
+
+    public string StoragePath { get; }
+
+    public static async Task<UpstreamOpenFeedHost> StartAsync(
+        string apiKey = TestPackageBuilder.DefaultApiKey,
+        CancellationToken cancellationToken = default)
+    {
+        var tempDirectory = Path.Combine(Path.GetTempPath(), $"openfeed-upstream-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDirectory);
+
+        var dbPath = Path.Combine(tempDirectory, "upstream.db");
+        var packagesPath = Path.Combine(tempDirectory, "packages");
+        Directory.CreateDirectory(packagesPath);
+
+        var port = GetFreePort();
+
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+        {
+            EnvironmentName = Environments.Development,
+        });
+
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["DisableSampleDataSeeder"] = "true",
+            ["ApiKey"] = apiKey,
+            ["Feed:Authentication:ApiKey"] = apiKey,
+            ["Feed:Authentication:AllowAnonymousPull"] = "true",
+            ["PackageDeletionBehavior"] = "HardDelete",
+            ["AllowPackageOverwrites"] = "true",
+            ["IsReadOnlyMode"] = "false",
+            ["EnablePackageMetadataBackfill"] = "false",
+            ["Database:Type"] = "Sqlite",
+            ["Search:Type"] = "Database",
+            ["Storage:Type"] = "FileSystem",
+            ["Storage:Path"] = packagesPath,
+            ["ConnectionStrings:Sqlite"] = $"Data Source={dbPath}",
+            ["Signing:Provider"] = null,
+            ["Logging:LogLevel:Default"] = "Warning",
+            ["Logging:LogLevel:Microsoft"] = "Warning",
+        });
+
+        builder.WebHost.UseKestrel(options => options.Listen(IPAddress.Loopback, port));
+
+        builder.Services.AddNuGetPackageApi(options =>
+        {
+            options.AddFileStorage();
+            options.AddSqliteDatabase("Sqlite");
+        });
+
+        var feed = builder.AddAvantiPointFeed(builder.Configuration.GetSection("Feed"));
+        feed.UseNuGet();
+
+        var app = builder.Build();
+        app.UseAvantiPointFeedPlatform();
+        app.UseRouting();
+        app.MapNuGetApiRoutes();
+
+        using (var scope = app.Services.CreateScope())
+        {
+            var context = scope.ServiceProvider.GetRequiredService<IContext>();
+            await context.RunMigrationsAsync(cancellationToken);
+        }
+
+        await app.StartAsync(cancellationToken);
+
+        var server = app.Services.GetRequiredService<IServer>();
+        var address = server.Features.Get<IServerAddressesFeature>()?.Addresses.FirstOrDefault()
+            ?? throw new InvalidOperationException("Failed to determine upstream server address.");
+
+        var baseAddress = new Uri(address);
+        var handler = new HttpClientHandler
+        {
+            AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
+        };
+        var client = new HttpClient(handler) { BaseAddress = baseAddress };
+
+        return new UpstreamOpenFeedHost(app, tempDirectory, client, baseAddress);
+    }
+
+    public async Task SeedPackageAsync(string packageId, string version, CancellationToken cancellationToken = default)
+    {
+        await TestPackageBuilder.PublishAsync(Client, packageId, version, cancellationToken: cancellationToken);
+    }
+
+    private static int GetFreePort()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        Client.Dispose();
+        await _app.StopAsync();
+        await _app.DisposeAsync();
+
+        try
+        {
+            if (Directory.Exists(_tempDirectory))
+            {
+                Directory.Delete(_tempDirectory, recursive: true);
+            }
+        }
+        catch
+        {
+            // Best effort cleanup
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add two-host integration tests for package origin and NuGet.org caching behavior.
- Document mirror caching strategies and deployment scenarios (including new deployment-scenarios guide and mirror/docs updates).
- Extend sample and integration-test infrastructure (FeedUnderTestHost, UpstreamOpenFeedHost, test README) to support origin/caching scenarios.
- Clean up documentation: remove issue/deferral references from user-facing docs while keeping general GitHub Issues support links.

Closes #581
Closes #583

## Test plan
- [ ] `dotnet test` on `tests/AvantiPoint.Packages.Integration.Tests` (origin/caching tests; external network tests may skip without connectivity).
- [ ] Review `docs/docs/deployment-scenarios.md` and `docs/docs/mirrors.md` for accuracy against configured feeds.
- [ ] Confirm CI `build-packages` workflow passes on the PR branch.
