### PR TITLE
Fix docs sidebar id for host email page

### DIFF
--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -80,7 +80,7 @@ const sidebars: SidebarsConfig = {
             type: 'category',
             label: 'Deployment',
             collapsible: true,
-            items: ['hosting', 'host/email'],
+            items: ['hosting', 'host/host-email'],
         },
         {
             type: 'category',


### PR DESCRIPTION
## Summary
- Fixes Docusaurus build failure on master after PR #608 merge.
- Sidebar referenced `host/email`, but the doc at `docs/docs/host/email.md` uses frontmatter `id: host-email`, so the registered doc id is `host/host-email`.

## Test plan
- [x] `cd docs && npm run build` (with `DOCUSAURUS_URL` / `DOCUSAURUS_BASE_URL` set as in CI)