### PR TITLE
Phase 3/4: Multi-feed hardening and pull-through proxy

### DIFF
--- a/docs/docs/deployment-scenarios.md
+++ b/docs/docs/deployment-scenarios.md
@@ -211,6 +211,89 @@ The legacy `Mirror` dictionary and `AddUpstreamSource` helpers are deprecated in
 
 Existing mirrored packages in the database retain their stored origin. New restores follow the `CachingStrategy` on each source.
 
+---
+
+## Unified multi-protocol host
+
+Run NuGet, npm, and OCI (default + named segments) on one hostname with isolated storage prefixes:
+
+```json
+{
+  "Feed": {
+    "Name": "production",
+    "Storage": {
+      "Prefix": "feeds/production/"
+    },
+    "NuGet": { "Enabled": true },
+    "Npm": {
+      "Enabled": true,
+      "IncludeMirroredPackages": false,
+      "Mirror": { "RegistryUrl": "https://registry.npmjs.org" }
+    },
+    "Oci": {
+      "Default": {
+        "Enabled": true,
+        "IncludeMirroredInCatalog": false
+      },
+      "Docker": { "Enabled": true },
+      "Helm": { "Enabled": true }
+    }
+  },
+  "Storage": {
+    "Type": "FileSystem",
+    "Path": "App_Data"
+  }
+}
+```
+
+Blob layout uses `feeds/{Feed.Name}/` for NuGet and npm (`npm/`), plus `oci/` and `oci/{segment}/` per OCI registration. Database rows are scoped by `FeedId` matching `Feed.Name`.
+
+> **Future:** A `feeds[]` array for unrelated logical tenants on one process is planned; NuGet v3 must remain at `/` on each tenant hostname.
+
+---
+
+## Dedicated hostnames (Kubernetes Ingress)
+
+Use separate Ingress rules when clients expect different URL shapes on the same backend deployment:
+
+| Hostname | Routes | Typical clients |
+|----------|--------|-----------------|
+| `nuget.company.com` | `/v3/`, `/api/` only | `dotnet restore`, Visual Studio |
+| `registry.company.com` | `/npm/`, `/v2/`, `/docker/v2/`, `/helm/v2/` | Docker, Helm, npm |
+
+Example Ingress snippet (same Service, two hosts):
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: openfeed
+spec:
+  rules:
+    - host: nuget.company.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: openfeed
+                port:
+                  number: 8080
+    - host: registry.company.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: openfeed
+                port:
+                  number: 8080
+```
+
+Set `Feed:PublicBaseUrl` (or reverse-proxy forwarded headers) so generated npm tarball URLs and OCI token endpoints use the hostname clients actually call. The NuGet-only host can omit npm/OCI UI links; the full registry host exposes all protocol surfaces.
+
 ## See Also
 
 - [Upstream Mirrors](mirrors.md) - Caching strategies, authentication, and troubleshooting

--- a/docs/docs/mirrors.md
+++ b/docs/docs/mirrors.md
@@ -458,6 +458,61 @@ dotnet nuget push Newtonsoft.Json.13.0.1.nupkg --source http://localhost:5000/v3
 
 Or use a script to bulk-import common packages.
 
+## npm upstream mirror
+
+Configure pull-through for the npm registry surface:
+
+```json
+{
+  "Feed": {
+    "Npm": {
+      "Enabled": true,
+      "IncludeMirroredPackages": false,
+      "Mirror": {
+        "RegistryUrl": "https://registry.npmjs.org"
+      }
+    }
+  }
+}
+```
+
+On packument or tarball cache miss, OpenFeed fetches from `RegistryUrl`, stores content per the active mirror policy, and sets package `Origin` to `Mirrored` or `Cached`. When `IncludeMirroredPackages` is `false`, `/-/v1/search` and the npm browse UI list published packages only; clients can still install mirrored packages.
+
+## OCI upstream mirror
+
+Configure pull-through per OCI registration (default or named segment):
+
+```json
+{
+  "Feed": {
+    "Oci": {
+      "Default": {
+        "Enabled": true,
+        "IncludeMirroredInCatalog": false,
+        "Mirror": {
+          "Registries": [
+            {
+              "Url": "https://registry-1.docker.io",
+              "Priority": 0
+            }
+          ]
+        }
+      },
+      "Docker": {
+        "Enabled": true,
+        "Mirror": {
+          "Registries": [
+            { "Url": "https://my-company.azurecr.io", "Username": "user", "Password": "token", "Priority": 0 }
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+On manifest or blob cache miss, the registry fetches from the lowest `Priority` upstream, streams to the client, and optionally persists blobs and tags. Mirrored tags respect `IncludeMirroredInCatalog` in `_catalog` and tag list APIs.
+
 ## See Also
 
 - [Deployment Scenarios](deployment-scenarios.md) - Commercial, enterprise mirror, and lightweight dev/Docker patterns

--- a/samples/OpenFeed/appsettings.json
+++ b/samples/OpenFeed/appsettings.json
@@ -46,6 +46,29 @@
     //"Path": "C://AnotherFolder/Packages"
   },
 
+  "Feed": {
+    "Name": "default",
+    "Storage": {
+      "Prefix": "feeds/default/"
+    },
+    "NuGet": { "Enabled": true },
+    "Npm": {
+      "Enabled": true,
+      "IncludeMirroredPackages": true,
+      "Mirror": {
+        "RegistryUrl": "https://registry.npmjs.org"
+      }
+    },
+    "Oci": {
+      "Default": {
+        "Enabled": true,
+        "IncludeMirroredInCatalog": false
+      },
+      "Docker": { "Enabled": true },
+      "Helm": { "Enabled": true }
+    }
+  },
+
   //"Storage": {
   //  "Type": "AzureBlobStorage",
   //  "AccountName": "my-account",

--- a/src/AvantiPoint.Feed.Platform/Authentication/NpmFeedAuthenticationAdapter.cs
+++ b/src/AvantiPoint.Feed.Platform/Authentication/NpmFeedAuthenticationAdapter.cs
@@ -53,16 +53,22 @@ public sealed class NpmFeedAuthenticationAdapter : IFeedProtocolAuthenticationAd
 
     private static bool TryGetBearerToken(HttpContext http, out string token)
     {
-        token = null;
+        token = string.Empty;
         try
         {
-            var header = AuthenticationHeaderValue.Parse(http.Request.Headers.Authorization);
+            var authorization = http.Request.Headers.Authorization.ToString();
+            if (string.IsNullOrWhiteSpace(authorization))
+            {
+                return false;
+            }
+
+            var header = AuthenticationHeaderValue.Parse(authorization);
             if (!string.Equals(header.Scheme, "Bearer", StringComparison.OrdinalIgnoreCase))
             {
                 return false;
             }
 
-            token = header.Parameter;
+            token = header.Parameter ?? string.Empty;
             return !string.IsNullOrEmpty(token);
         }
         catch

--- a/src/AvantiPoint.Feed.Platform/Authentication/NuGetFeedAuthenticationAdapter.cs
+++ b/src/AvantiPoint.Feed.Platform/Authentication/NuGetFeedAuthenticationAdapter.cs
@@ -47,7 +47,7 @@ public sealed class NuGetFeedAuthenticationAdapter : IFeedProtocolAuthentication
         }
         else
         {
-            result = NuGetAuthenticationResult.Fail("No credentials provided.", http.Request.Host.Value);
+            result = NuGetAuthenticationResult.Fail("No credentials provided.", http.Request.Host.Value ?? string.Empty);
         }
 
         if (result.Succeeded)
@@ -61,25 +61,31 @@ public sealed class NuGetFeedAuthenticationAdapter : IFeedProtocolAuthentication
             headers["WWW-Authenticate"] = FormatBasicRealm(result.Realm);
         }
 
-        headers["X-Nuget-Warning"] = result.Message;
-        headers["Server"] = result.Server;
+        headers["X-Nuget-Warning"] = result.Message ?? string.Empty;
+        headers["Server"] = result.Server ?? string.Empty;
 
-        return FeedAuthenticationResult.Fail(result.Message, headers);
+        return FeedAuthenticationResult.Fail(result.Message ?? "Authentication failed.", headers);
     }
 
     private static bool TryGetApiKey(HttpContext http, out string apiKey)
     {
-        apiKey = http.Request.Headers[ApiKeyHeader];
+        apiKey = http.Request.Headers[ApiKeyHeader].ToString();
         return !string.IsNullOrEmpty(apiKey);
     }
 
     private static bool TryGetBasicCredentials(HttpContext http, out string username, out string password)
     {
-        username = null;
-        password = null;
+        username = string.Empty;
+        password = string.Empty;
         try
         {
-            var authHeader = AuthenticationHeaderValue.Parse(http.Request.Headers.Authorization);
+            var authorization = http.Request.Headers.Authorization.ToString();
+            if (string.IsNullOrWhiteSpace(authorization))
+            {
+                return false;
+            }
+
+            var authHeader = AuthenticationHeaderValue.Parse(authorization);
             if (!string.Equals(authHeader.Scheme, "Basic", StringComparison.OrdinalIgnoreCase))
             {
                 return false;

--- a/src/AvantiPoint.Feed.Platform/Authentication/OciFeedAuthenticationAdapter.cs
+++ b/src/AvantiPoint.Feed.Platform/Authentication/OciFeedAuthenticationAdapter.cs
@@ -97,10 +97,16 @@ public sealed class OciFeedAuthenticationAdapter : IFeedProtocolAuthenticationAd
 
     private static bool TryGetBearerToken(HttpContext http, out string token)
     {
-        token = null!;
+        token = string.Empty;
         try
         {
-            var header = System.Net.Http.Headers.AuthenticationHeaderValue.Parse(http.Request.Headers.Authorization);
+            var authorization = http.Request.Headers.Authorization.ToString();
+            if (string.IsNullOrWhiteSpace(authorization))
+            {
+                return false;
+            }
+
+            var header = System.Net.Http.Headers.AuthenticationHeaderValue.Parse(authorization);
             if (!string.Equals(header.Scheme, "Bearer", StringComparison.OrdinalIgnoreCase))
             {
                 return false;
@@ -122,7 +128,13 @@ public sealed class OciFeedAuthenticationAdapter : IFeedProtocolAuthenticationAd
 
         try
         {
-            var header = System.Net.Http.Headers.AuthenticationHeaderValue.Parse(http.Request.Headers.Authorization);
+            var authorization = http.Request.Headers.Authorization.ToString();
+            if (string.IsNullOrWhiteSpace(authorization))
+            {
+                return false;
+            }
+
+            var header = System.Net.Http.Headers.AuthenticationHeaderValue.Parse(authorization);
             if (!string.Equals(header.Scheme, "Basic", StringComparison.OrdinalIgnoreCase)
                 || string.IsNullOrEmpty(header.Parameter))
             {

--- a/src/AvantiPoint.Feed.Platform/Configuration/FeedAuthenticationOptions.cs
+++ b/src/AvantiPoint.Feed.Platform/Configuration/FeedAuthenticationOptions.cs
@@ -2,7 +2,7 @@ namespace AvantiPoint.Feed.Platform.Configuration;
 
 public class FeedAuthenticationOptions
 {
-    public string ApiKey { get; set; }
+    public string? ApiKey { get; set; }
 
     public bool AllowAnonymousPull { get; set; }
 }

--- a/src/AvantiPoint.Feed.Platform/Configuration/FeedOptions.cs
+++ b/src/AvantiPoint.Feed.Platform/Configuration/FeedOptions.cs
@@ -8,7 +8,7 @@ public class FeedOptions
     /// Optional absolute public base URL for feed links (reverse proxy / path-prefix scenarios).
     /// Example: https://packages.example.com/myfeed
     /// </summary>
-    public string PublicBaseUrl { get; set; }
+    public string? PublicBaseUrl { get; set; }
 
     public FeedStorageOptions Storage { get; set; } = new();
 

--- a/src/AvantiPoint.Feed.Platform/Configuration/NpmFeedOptions.cs
+++ b/src/AvantiPoint.Feed.Platform/Configuration/NpmFeedOptions.cs
@@ -17,5 +17,10 @@ public class NpmFeedOptions
     /// </summary>
     public long MaxTarballBytes { get; set; } = 100 * 1024 * 1024;
 
+    /// <summary>
+    /// When false, npm search and UI browse list only published packages (mirrored/cached hidden).
+    /// </summary>
+    public bool IncludeMirroredPackages { get; set; } = true;
+
     public NpmMirrorOptions Mirror { get; set; } = new();
 }

--- a/src/AvantiPoint.Feed.Platform/Configuration/NpmMirrorOptions.cs
+++ b/src/AvantiPoint.Feed.Platform/Configuration/NpmMirrorOptions.cs
@@ -1,6 +1,10 @@
+using AvantiPoint.Feed.Platform.Mirror;
+
 namespace AvantiPoint.Feed.Platform.Configuration;
 
 public class NpmMirrorOptions
 {
     public string RegistryUrl { get; set; } = "https://registry.npmjs.org";
+
+    public MirrorCachingStrategy CachingStrategy { get; set; } = MirrorCachingStrategy.IndexAndCache;
 }

--- a/src/AvantiPoint.Feed.Platform/Configuration/OciFeedOptions.cs
+++ b/src/AvantiPoint.Feed.Platform/Configuration/OciFeedOptions.cs
@@ -13,5 +13,7 @@ public class OciFeedOptions
 
     public bool IncludeMirroredInCatalog { get; set; }
 
+    public OciMirrorOptions Mirror { get; set; } = new();
+
     public OciPlatformPolicyOptions PlatformPolicy { get; set; } = new();
 }

--- a/src/AvantiPoint.Feed.Platform/Configuration/OciMirrorOptions.cs
+++ b/src/AvantiPoint.Feed.Platform/Configuration/OciMirrorOptions.cs
@@ -1,17 +1,10 @@
+using AvantiPoint.Feed.Platform.Mirror;
+
 namespace AvantiPoint.Feed.Platform.Configuration;
 
 public class OciMirrorOptions
 {
     public IList<OciUpstreamRegistryOptions> Registries { get; set; } = [];
-}
 
-public class OciUpstreamRegistryOptions
-{
-    public string Url { get; set; } = string.Empty;
-
-    public string? Username { get; set; }
-
-    public string? Password { get; set; }
-
-    public int Priority { get; set; }
+    public MirrorCachingStrategy CachingStrategy { get; set; } = MirrorCachingStrategy.IndexAndCache;
 }

--- a/src/AvantiPoint.Feed.Platform/Configuration/OciUpstreamRegistryOptions.cs
+++ b/src/AvantiPoint.Feed.Platform/Configuration/OciUpstreamRegistryOptions.cs
@@ -1,0 +1,12 @@
+namespace AvantiPoint.Feed.Platform.Configuration;
+
+public class OciUpstreamRegistryOptions
+{
+    public string Url { get; set; } = string.Empty;
+
+    public string? Username { get; set; }
+
+    public string? Password { get; set; }
+
+    public int Priority { get; set; }
+}

--- a/src/AvantiPoint.Feed.Platform/Extensions/FeedServiceCollectionExtensions.cs
+++ b/src/AvantiPoint.Feed.Platform/Extensions/FeedServiceCollectionExtensions.cs
@@ -28,6 +28,8 @@ public static class FeedServiceCollectionExtensions
         }
 
         services.TryAddScoped<ISurfaceContextAccessor, SurfaceContextAccessor>();
+        services.RemoveAll<Packages.Core.IFeedScope>();
+        services.AddSingleton<Packages.Core.IFeedScope, FeedScope>();
         services.TryAddSingleton<IPublicBaseUrlProvider, PublicBaseUrlProvider>();
         services.TryAddScoped<IStorageBackendFactory, StorageBackendFactory>();
 
@@ -35,7 +37,7 @@ public static class FeedServiceCollectionExtensions
         services.TryAddEnumerable(ServiceDescriptor.Scoped<IFeedProtocolAuthenticationAdapter, NpmFeedAuthenticationAdapter>());
         services.TryAddEnumerable(ServiceDescriptor.Scoped<IFeedProtocolAuthenticationAdapter, OciFeedAuthenticationAdapter>());
         services.TryAddScoped<IFeedAuthenticationService, CompositeFeedAuthenticationService>();
-        services.TryAddSingleton<IMirrorPolicyService, DefaultMirrorPolicyService>();
+        services.TryAddSingleton<IMirrorPolicyService, ConfigurableMirrorPolicyService>();
         services.TryAddSingleton<FeedMetricsService>();
 
         services.TryAddSingleton(CreateDefaultFeedRegistry);

--- a/src/AvantiPoint.Feed.Platform/Extensions/FeedServiceCollectionExtensions.cs
+++ b/src/AvantiPoint.Feed.Platform/Extensions/FeedServiceCollectionExtensions.cs
@@ -18,7 +18,7 @@ public static class FeedServiceCollectionExtensions
 {
     public static IServiceCollection AddAvantiPointFeedPlatform(
         this IServiceCollection services,
-        IConfiguration configuration = null)
+        IConfiguration? configuration = null)
     {
         services.AddOptions<FeedOptions>();
         if (configuration is not null)
@@ -47,7 +47,7 @@ public static class FeedServiceCollectionExtensions
 
     public static FeedBuilder AddAvantiPointFeed(
         this WebApplicationBuilder builder,
-        IConfigurationSection feedSection = null)
+        IConfigurationSection? feedSection = null)
     {
         builder.Services.AddAvantiPointFeedPlatform(builder.Configuration);
 

--- a/src/AvantiPoint.Feed.Platform/FeedBuilder.cs
+++ b/src/AvantiPoint.Feed.Platform/FeedBuilder.cs
@@ -63,8 +63,8 @@ public sealed class FeedBuilder
 
     public FeedBuilder UseOci(
         string segment,
-        string surfaceId = null,
-        Action<OciSurfaceOptionsBuilder> configure = null,
+        string? surfaceId = null,
+        Action<OciSurfaceOptionsBuilder>? configure = null,
         bool allowV2EmbeddedSegmentRouting = false)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(segment);

--- a/src/AvantiPoint.Feed.Platform/FeedScope.cs
+++ b/src/AvantiPoint.Feed.Platform/FeedScope.cs
@@ -1,0 +1,13 @@
+namespace AvantiPoint.Feed.Platform;
+
+public sealed class FeedScope : Packages.Core.IFeedScope
+{
+    private readonly IFeedRegistry _registry;
+
+    public FeedScope(IFeedRegistry registry)
+    {
+        _registry = registry ?? throw new ArgumentNullException(nameof(registry));
+    }
+
+    public string FeedId => _registry.Feed.FeedId;
+}

--- a/src/AvantiPoint.Feed.Platform/Middleware/FeedRouterMiddleware.cs
+++ b/src/AvantiPoint.Feed.Platform/Middleware/FeedRouterMiddleware.cs
@@ -145,7 +145,7 @@ public sealed class FeedRouterMiddleware
 
     private static bool TryGetNamedOciSegment(string path, out string segment)
     {
-        segment = null;
+        segment = string.Empty;
         var parts = path.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
         if (parts.Length >= 2
             && parts[1].Equals("v2", StringComparison.OrdinalIgnoreCase)

--- a/src/AvantiPoint.Feed.Platform/Mirror/ConfigurableMirrorPolicyService.cs
+++ b/src/AvantiPoint.Feed.Platform/Mirror/ConfigurableMirrorPolicyService.cs
@@ -24,7 +24,12 @@ public sealed class ConfigurableMirrorPolicyService : IMirrorPolicyService
     }
 
     public MirrorCachingStrategy GetStrategy(FeedProtocol protocol, string? surfaceId = null) =>
-        MirrorCachingStrategy.IndexAndCache;
+        protocol switch
+        {
+            FeedProtocol.Npm => _npmOptions.Mirror.CachingStrategy,
+            FeedProtocol.Oci => GetOciOptions(surfaceId).Mirror.CachingStrategy,
+            _ => MirrorCachingStrategy.IndexAndCache,
+        };
 
     public bool IncludeInDiscovery(FeedProtocol protocol, PackageOrigin origin, string? surfaceId = null) =>
         origin switch

--- a/src/AvantiPoint.Feed.Platform/Mirror/ConfigurableMirrorPolicyService.cs
+++ b/src/AvantiPoint.Feed.Platform/Mirror/ConfigurableMirrorPolicyService.cs
@@ -1,0 +1,48 @@
+using AvantiPoint.Feed.Platform.Configuration;
+using AvantiPoint.Packages.Core;
+using Microsoft.Extensions.Options;
+
+namespace AvantiPoint.Feed.Platform.Mirror;
+
+/// <summary>
+/// Applies per-protocol discovery and caching policy from feed configuration.
+/// </summary>
+public sealed class ConfigurableMirrorPolicyService : IMirrorPolicyService
+{
+    private readonly SearchOptions _searchOptions;
+    private readonly NpmFeedOptions _npmOptions;
+    private readonly IOptionsMonitor<OciFeedOptions> _ociOptionsMonitor;
+
+    public ConfigurableMirrorPolicyService(
+        IOptions<SearchOptions> searchOptions,
+        IOptions<NpmFeedOptions> npmOptions,
+        IOptionsMonitor<OciFeedOptions> ociOptionsMonitor)
+    {
+        _searchOptions = searchOptions?.Value ?? new SearchOptions();
+        _npmOptions = npmOptions?.Value ?? new NpmFeedOptions();
+        _ociOptionsMonitor = ociOptionsMonitor;
+    }
+
+    public MirrorCachingStrategy GetStrategy(FeedProtocol protocol, string? surfaceId = null) =>
+        MirrorCachingStrategy.IndexAndCache;
+
+    public bool IncludeInDiscovery(FeedProtocol protocol, PackageOrigin origin, string? surfaceId = null) =>
+        origin switch
+        {
+            PackageOrigin.Published => true,
+            PackageOrigin.Cached => false,
+            PackageOrigin.Mirrored => protocol switch
+            {
+                FeedProtocol.NuGet => _searchOptions.IncludeMirroredPackages,
+                FeedProtocol.Npm => _npmOptions.IncludeMirroredPackages,
+                FeedProtocol.Oci => GetOciOptions(surfaceId).IncludeMirroredInCatalog,
+                _ => false,
+            },
+            _ => false,
+        };
+
+    private OciFeedOptions GetOciOptions(string? surfaceId) =>
+        string.IsNullOrEmpty(surfaceId)
+            ? _ociOptionsMonitor.Get("OciFeed:default")
+            : _ociOptionsMonitor.Get(OciSurfaceOptionsBuilder.GetOptionsName(surfaceId));
+}

--- a/src/AvantiPoint.Feed.Platform/PublicBaseUrlProvider.cs
+++ b/src/AvantiPoint.Feed.Platform/PublicBaseUrlProvider.cs
@@ -29,7 +29,7 @@ public sealed class PublicBaseUrlProvider : IPublicBaseUrlProvider
 
         var request = httpContext.Request;
         var scheme = GetForwardedHeader(request, "X-Forwarded-Proto") ?? request.Scheme;
-        var host = GetForwardedHeader(request, "X-Forwarded-Host") ?? request.Host.Value;
+        var host = GetForwardedHeader(request, "X-Forwarded-Host") ?? request.Host.Value ?? "localhost";
         var pathBase = GetForwardedHeader(request, "X-Forwarded-Prefix")
             ?? request.PathBase.Value
             ?? _packageFeedOptions.CurrentValue.PathBase
@@ -55,7 +55,7 @@ public sealed class PublicBaseUrlProvider : IPublicBaseUrlProvider
         return new UriBuilder(origin.Scheme, origin.Host, origin.Port, combinedPath + "/").Uri;
     }
 
-    private static string GetForwardedHeader(HttpRequest request, string headerName)
+    private static string? GetForwardedHeader(HttpRequest request, string headerName)
     {
         if (!request.Headers.TryGetValue(headerName, out var values))
         {

--- a/src/AvantiPoint.Packages.Core/DefaultFeedScope.cs
+++ b/src/AvantiPoint.Packages.Core/DefaultFeedScope.cs
@@ -1,0 +1,6 @@
+namespace AvantiPoint.Packages.Core;
+
+public sealed class DefaultFeedScope : IFeedScope
+{
+    public string FeedId => FeedConstants.DefaultFeedId;
+}

--- a/src/AvantiPoint.Packages.Core/Extensions/DependencyInjectionExtensions.cs
+++ b/src/AvantiPoint.Packages.Core/Extensions/DependencyInjectionExtensions.cs
@@ -125,6 +125,7 @@ namespace AvantiPoint.Packages.Core
             services.TryAddTransient<FileStorageService>();
             services.TryAddTransient<IMirrorService, MirrorService>();
             services.TryAddSingleton<NullStorageService>();
+            services.TryAddSingleton<IFeedScope, DefaultFeedScope>();
             services.TryAddTransient<PackageService>();
             services.TryAddTransient<IPackageService>(provider => provider.GetRequiredService<PackageService>());
             services.TryAddScoped<IPackageSourceService, PackageSourceService>();

--- a/src/AvantiPoint.Packages.Core/IFeedScope.cs
+++ b/src/AvantiPoint.Packages.Core/IFeedScope.cs
@@ -1,0 +1,9 @@
+namespace AvantiPoint.Packages.Core;
+
+/// <summary>
+/// Resolves the active logical feed identifier for the current deployment scope.
+/// </summary>
+public interface IFeedScope
+{
+    string FeedId { get; }
+}

--- a/src/AvantiPoint.Packages.Core/Indexing/PackageIndexingService.cs
+++ b/src/AvantiPoint.Packages.Core/Indexing/PackageIndexingService.cs
@@ -27,6 +27,7 @@ namespace AvantiPoint.Packages.Core
         private readonly IOptions<CoreSigningOptions> _signingOptions;
         private readonly Signing.RepositorySigningCertificateService _certificateService;
         private readonly ILogger<PackageIndexingService> _logger;
+        private readonly IFeedScope _feedScope;
 
         public PackageIndexingService(
             IPackageService packages,
@@ -39,9 +40,11 @@ namespace AvantiPoint.Packages.Core
             PackageSignatureStripper signatureStripper,
             IOptions<CoreSigningOptions> signingOptions,
             Signing.RepositorySigningCertificateService certificateService,
-            ILogger<PackageIndexingService> logger)
+            ILogger<PackageIndexingService> logger,
+            IFeedScope feedScope)
         {
             _packages = packages ?? throw new ArgumentNullException(nameof(packages));
+            _feedScope = feedScope ?? throw new ArgumentNullException(nameof(feedScope));
             _storage = storage ?? throw new ArgumentNullException(nameof(storage));
             _search = search ?? throw new ArgumentNullException(nameof(search));
             _time = time ?? throw new ArgumentNullException(nameof(time));
@@ -72,6 +75,7 @@ namespace AvantiPoint.Packages.Core
             {
                 using var packageReader = new PackageArchiveReader(packageStream, leaveStreamOpen: true);
                 package = await packageReader.GetPackageMetadata();
+                package.FeedId = _feedScope.FeedId;
                 package.Origin = ingestionContext.Origin;
                 package.PackageSourceId = ingestionContext.PackageSourceId;
 

--- a/src/AvantiPoint.Packages.Core/Metadata/DefaultPackageMetadataService.cs
+++ b/src/AvantiPoint.Packages.Core/Metadata/DefaultPackageMetadataService.cs
@@ -22,6 +22,7 @@ namespace AvantiPoint.Packages.Core
         private readonly IContext _context;
         private readonly IUrlGenerator _urlGenerator;
         private readonly SearchOptions _searchOptions;
+        private readonly IFeedScope _feedScope;
 
         public DefaultPackageMetadataService(
             IContext context,
@@ -29,7 +30,8 @@ namespace AvantiPoint.Packages.Core
             IPackageService packages,
             RegistrationBuilder builder,
             IUrlGenerator urlGenerator,
-            IOptions<SearchOptions> searchOptions)
+            IOptions<SearchOptions> searchOptions,
+            IFeedScope feedScope)
         {
             _context = context ?? throw new ArgumentNullException(nameof(context));
             _mirror = mirror ?? throw new ArgumentNullException(nameof(mirror));
@@ -37,6 +39,7 @@ namespace AvantiPoint.Packages.Core
             _builder = builder ?? throw new ArgumentNullException(nameof(builder));
             _urlGenerator = urlGenerator;
             _searchOptions = searchOptions?.Value ?? throw new ArgumentNullException(nameof(searchOptions));
+            _feedScope = feedScope ?? throw new ArgumentNullException(nameof(feedScope));
         }
 
         public async Task<NuGetApiRegistrationIndexResponse> GetRegistrationIndexOrNullAsync(
@@ -145,6 +148,7 @@ namespace AvantiPoint.Packages.Core
                     _context.Packages
                         .Include(x => x.Dependencies)
                         .Include(x => x.PackageTypes)
+                        .Where(x => x.FeedId == _feedScope.FeedId)
                         .Where(x => x.Id.ToLower() == packageId.ToLower()),
                     _searchOptions)
                 .ToListAsync(cancellationToken);
@@ -160,6 +164,7 @@ namespace AvantiPoint.Packages.Core
 
             // Check which dependencies exist locally in a single query
             var localDependencies = await _context.Packages
+                .Where(p => p.FeedId == _feedScope.FeedId)
                 .Where(p => allDependencyIds.Contains(p.Id))
                 .Select(p => p.Id)
                 .Distinct()

--- a/src/AvantiPoint.Packages.Core/PackageService.cs
+++ b/src/AvantiPoint.Packages.Core/PackageService.cs
@@ -16,12 +16,19 @@ namespace AvantiPoint.Packages.Core
     {
         private readonly IContext _context;
         private readonly IHttpContextAccessor _contextAccessor;
+        private readonly IFeedScope _feedScope;
 
-        public PackageService(IContext context, IHttpContextAccessor contextAccessor)
+        public PackageService(
+            IContext context,
+            IHttpContextAccessor contextAccessor,
+            IFeedScope feedScope)
         {
             _context = context ?? throw new ArgumentNullException(nameof(context));
             _contextAccessor = contextAccessor ?? throw new ArgumentNullException(nameof(contextAccessor));
+            _feedScope = feedScope ?? throw new ArgumentNullException(nameof(feedScope));
         }
+
+        private string CurrentFeedId => _feedScope.FeedId;
 
         public async Task<PackageAddResult> AddAsync(Package package, CancellationToken cancellationToken)
         {
@@ -44,6 +51,7 @@ namespace AvantiPoint.Packages.Core
         {
             return await _context
                 .Packages
+                .Where(p => p.FeedId == CurrentFeedId)
                 .Where(p => p.Id == id)
                 .AnyAsync(cancellationToken);
         }
@@ -52,6 +60,7 @@ namespace AvantiPoint.Packages.Core
         {
             return await _context
                 .Packages
+                .Where(p => p.FeedId == CurrentFeedId)
                 .Where(p => p.Id == id)
                 .Where(p => p.NormalizedVersionString == version.ToNormalizedString())
                 .AnyAsync(cancellationToken);
@@ -68,6 +77,7 @@ namespace AvantiPoint.Packages.Core
         {
             var query = _context.Packages
                 .AsNoTracking()
+                .Where(p => p.FeedId == CurrentFeedId)
                 .Where(p => p.Id == id);
 
             if (!includeUnlisted)
@@ -88,6 +98,7 @@ namespace AvantiPoint.Packages.Core
             var query = _context.Packages
                 .Include(p => p.Dependencies)
                 .Include(p => p.TargetFrameworks)
+                .Where(p => p.FeedId == CurrentFeedId)
                 .Where(p => p.Id == id)
                 .Where(p => p.NormalizedVersionString == version.ToNormalizedString());
 
@@ -112,6 +123,7 @@ namespace AvantiPoint.Packages.Core
         public async Task<bool> AddDownloadAsync(string id, NuGetVersion version, CancellationToken cancellationToken)
         {
             var package = await _context.Packages
+                .Where(p => p.FeedId == CurrentFeedId)
                 .Where(p => p.Id == id)
                 .Where(p => p.NormalizedVersionString == version.ToNormalizedString())
                 .FirstOrDefaultAsync();
@@ -185,6 +197,7 @@ namespace AvantiPoint.Packages.Core
             CancellationToken cancellationToken)
         {
             var package = await _context.Packages
+                .Where(p => p.FeedId == CurrentFeedId)
                 .Where(p => p.Id == id)
                 .Where(p => p.NormalizedVersionString == version.ToNormalizedString())
                 .FirstOrDefaultAsync();

--- a/src/AvantiPoint.Packages.Core/PackageService.cs
+++ b/src/AvantiPoint.Packages.Core/PackageService.cs
@@ -184,6 +184,7 @@ namespace AvantiPoint.Packages.Core
         public async Task<bool> HardDeletePackageAsync(string id, NuGetVersion version, CancellationToken cancellationToken)
         {
             var package = await _context.Packages
+                .Where(p => p.FeedId == CurrentFeedId)
                 .Where(p => p.Id == id)
                 .Where(p => p.NormalizedVersionString == version.ToNormalizedString())
                 .Include(p => p.Dependencies)

--- a/src/AvantiPoint.Packages.Core/PackageService.cs
+++ b/src/AvantiPoint.Packages.Core/PackageService.cs
@@ -70,7 +70,18 @@ namespace AvantiPoint.Packages.Core
         {
             // Delegate to context-specific implementation
             // Each provider implements this optimally for its backend
-            return await _context.FindPackagesAsync(id, includeUnlisted, cancellationToken);
+            var packages = await _context.FindPackagesAsync(id, includeUnlisted, cancellationToken);
+            var packageKeys = (await _context.Packages
+                .AsNoTracking()
+                .Where(p => p.FeedId == CurrentFeedId)
+                .Where(p => p.Id == id)
+                .Select(p => p.Key)
+                .ToListAsync(cancellationToken))
+                .ToHashSet();
+
+            return packages
+                .Where(p => packageKeys.Contains(p.Key))
+                .ToList();
         }
 
         public async Task<IReadOnlyList<NuGetVersion>> FindVersionsAsync(string id, bool includeUnlisted, CancellationToken cancellationToken)

--- a/src/AvantiPoint.Packages.Core/Search/DatabaseSearchService.cs
+++ b/src/AvantiPoint.Packages.Core/Search/DatabaseSearchService.cs
@@ -210,6 +210,7 @@ namespace AvantiPoint.Packages.Core
             var downloadCounts = await PackageOriginFilter.ApplyDiscoveryFilter(
                     _context.Packages
                         .AsNoTracking()
+                        .Where(p => p.FeedId == _feedScope.FeedId)
                         .Where(p => packageIds.Contains(p.Id)),
                     _searchOptions)
                 .GroupBy(p => p.Id)

--- a/src/AvantiPoint.Packages.Core/Search/DatabaseSearchService.cs
+++ b/src/AvantiPoint.Packages.Core/Search/DatabaseSearchService.cs
@@ -56,6 +56,7 @@ namespace AvantiPoint.Packages.Core
             var packageDownloads = await PackageOriginFilter.ApplyDiscoveryFilter(
                     _context.Packages
                         .AsNoTracking()
+                        .Where(p => p.FeedId == _feedScope.FeedId)
                         .Where(p => baseQuery.Select(bp => bp.Id).Contains(p.Id)),
                     _searchOptions)
                 .GroupBy(p => p.Id)
@@ -90,6 +91,7 @@ namespace AvantiPoint.Packages.Core
             var allVersionsQuery = PackageOriginFilter.ApplyDiscoveryFilter(
                 _context.Packages
                     .AsNoTracking()
+                    .Where(p => p.FeedId == _feedScope.FeedId)
                     .Where(p => packageIds.Contains(p.Id)),
                 _searchOptions);
 

--- a/src/AvantiPoint.Packages.Core/Search/DatabaseSearchService.cs
+++ b/src/AvantiPoint.Packages.Core/Search/DatabaseSearchService.cs
@@ -8,6 +8,8 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using NuGet.Versioning;
 
+#nullable enable
+
 namespace AvantiPoint.Packages.Core
 {
     public class DatabaseSearchService : ISearchService
@@ -74,7 +76,7 @@ namespace AvantiPoint.Packages.Core
             var latestPackagesUnordered = await baseQuery
                 .Include(p => p.PackageTypes)
                 .GroupBy(p => p.Id)
-                .Select(g => g.OrderByDescending(p => p.Published).FirstOrDefault())
+                .Select(g => g.OrderByDescending(p => p.Published).First())
                 .ToListAsync(cancellationToken);
 
             // Then order in memory using the download counts and apply pagination
@@ -336,11 +338,11 @@ namespace AvantiPoint.Packages.Core
 
         private IQueryable<Package> AddSearchFilters(
             IQueryable<Package> query,
-            string searchQuery,
+            string? searchQuery,
             bool includePrerelease,
             bool includeSemVer2,
-            string packageType,
-            IReadOnlyList<string> frameworks)
+            string? packageType,
+            IReadOnlyList<string>? frameworks)
         {
             searchQuery = searchQuery?.Trim();
             if (!includePrerelease)
@@ -375,7 +377,7 @@ namespace AvantiPoint.Packages.Core
             return PackageOriginFilter.ApplyDiscoveryFilter(query, _searchOptions);
         }
 
-        private IReadOnlyList<string> GetCompatibleFrameworksOrNull(string framework)
+        private IReadOnlyList<string>? GetCompatibleFrameworksOrNull(string? framework)
         {
             if (framework == null) return null;
 

--- a/src/AvantiPoint.Packages.Core/Search/DatabaseSearchService.cs
+++ b/src/AvantiPoint.Packages.Core/Search/DatabaseSearchService.cs
@@ -16,17 +16,20 @@ namespace AvantiPoint.Packages.Core
         private readonly IFrameworkCompatibilityService _frameworks;
         private readonly IUrlGenerator _url;
         private readonly SearchOptions _searchOptions;
+        private readonly IFeedScope _feedScope;
 
         public DatabaseSearchService(
             IContext context,
             IFrameworkCompatibilityService frameworks,
             IUrlGenerator url,
-            IOptions<SearchOptions> searchOptions)
+            IOptions<SearchOptions> searchOptions,
+            IFeedScope feedScope)
         {
             _context = context ?? throw new ArgumentNullException(nameof(context));
             _frameworks = frameworks ?? throw new ArgumentNullException(nameof(frameworks));
             _url = url ?? throw new ArgumentNullException(nameof(url));
             _searchOptions = searchOptions?.Value ?? throw new ArgumentNullException(nameof(searchOptions));
+            _feedScope = feedScope ?? throw new ArgumentNullException(nameof(feedScope));
         }
 
         public async Task<SearchResponse> SearchAsync(
@@ -35,7 +38,9 @@ namespace AvantiPoint.Packages.Core
         {
             var count = await SearchCountAsync(request, cancellationToken);
             var frameworks = GetCompatibleFrameworksOrNull(request.Framework);
-            IQueryable<Package> baseQuery = _context.Packages.AsNoTracking();
+            IQueryable<Package> baseQuery = _context.Packages
+                .AsNoTracking()
+                .Where(p => p.FeedId == _feedScope.FeedId);
 
             // Apply search filters (e.g., query, prerelease, package type, frameworks)
             baseQuery = AddSearchFilters(
@@ -175,7 +180,9 @@ namespace AvantiPoint.Packages.Core
             AutocompleteRequest request,
             CancellationToken cancellationToken)
         {
-            IQueryable<Package> search = _context.Packages.AsNoTracking();
+            IQueryable<Package> search = _context.Packages
+                .AsNoTracking()
+                .Where(p => p.FeedId == _feedScope.FeedId);
 
             if (!string.IsNullOrEmpty(request.Query))
             {
@@ -231,6 +238,7 @@ namespace AvantiPoint.Packages.Core
             var packageId = request.PackageId.ToLower();
             IQueryable<Package> search = _context
                 .Packages
+                .Where(p => p.FeedId == _feedScope.FeedId)
                 .Where(p => p.Id.ToLower().Equals(packageId));
             search = AddSearchFilters(
                 search,
@@ -258,6 +266,7 @@ namespace AvantiPoint.Packages.Core
             var dependentsQuery = _context
                 .Packages
                 .AsNoTracking()
+                .Where(p => p.FeedId == _feedScope.FeedId)
                 .Where(p => p.Listed)
                 .Where(p => p.Dependencies.Any(d => d.Id == packageId));
 
@@ -306,7 +315,7 @@ namespace AvantiPoint.Packages.Core
             CancellationToken cancellationToken)
         {
             var frameworks = GetCompatibleFrameworksOrNull(request.Framework);
-            IQueryable<Package> search = _context.Packages;
+            IQueryable<Package> search = _context.Packages.Where(p => p.FeedId == _feedScope.FeedId);
 
             search = AddSearchFilters(
                 search,

--- a/src/AvantiPoint.Packages.Core/Search/DatabaseSearchService.cs
+++ b/src/AvantiPoint.Packages.Core/Search/DatabaseSearchService.cs
@@ -284,6 +284,7 @@ namespace AvantiPoint.Packages.Core
             var downloadCounts = await PackageOriginFilter.ApplyDiscoveryFilter(
                     _context.Packages
                         .AsNoTracking()
+                        .Where(p => p.FeedId == _feedScope.FeedId)
                         .Where(p => dependentPackageIds.Contains(p.Id)),
                     _searchOptions)
                 .GroupBy(p => new { p.Id, p.Description })

--- a/src/AvantiPoint.Packages.Registry.Npm/Authentication/AuthorizedNpmFilter.cs
+++ b/src/AvantiPoint.Packages.Registry.Npm/Authentication/AuthorizedNpmFilter.cs
@@ -21,7 +21,7 @@ public abstract class AuthorizedNpmFilter : IEndpointFilter
         _surfaceAccessor = surfaceAccessor;
     }
 
-    public async ValueTask<object> InvokeAsync(EndpointFilterInvocationContext context, EndpointFilterDelegate next)
+    public async ValueTask<object?> InvokeAsync(EndpointFilterInvocationContext context, EndpointFilterDelegate next)
     {
         var surface = _surfaceAccessor.Current;
         if (surface is null || surface.Protocol != FeedProtocol.Npm)

--- a/src/AvantiPoint.Packages.Registry.Npm/INpmPackageService.cs
+++ b/src/AvantiPoint.Packages.Registry.Npm/INpmPackageService.cs
@@ -20,4 +20,19 @@ public interface INpmPackageService
         JsonObject versionMetadata,
         Uri publicBaseUrl,
         CancellationToken cancellationToken = default);
+
+    Task<NpmSearchResult> SearchAsync(
+        string feedId,
+        string? query,
+        int from,
+        int size,
+        CancellationToken cancellationToken = default);
 }
+
+public sealed record NpmSearchResult(int Total, IReadOnlyList<NpmSearchObject> Objects);
+
+public sealed record NpmSearchObject(
+    string Name,
+    string Version,
+    string? Description,
+    DateTime? Published);

--- a/src/AvantiPoint.Packages.Registry.Npm/INpmPackageService.cs
+++ b/src/AvantiPoint.Packages.Registry.Npm/INpmPackageService.cs
@@ -10,7 +10,12 @@ public interface INpmPackageService
         Uri publicBaseUrl,
         CancellationToken cancellationToken = default);
 
-    Task<Stream?> GetTarballAsync(string feedId, string packageName, string tarballFileName, CancellationToken cancellationToken = default);
+    Task<Stream?> GetTarballAsync(
+        string feedId,
+        string packageName,
+        string tarballFileName,
+        Uri publicBaseUrl,
+        CancellationToken cancellationToken = default);
 
     Task PublishAsync(
         string feedId,

--- a/src/AvantiPoint.Packages.Registry.Npm/NpmMirrorService.cs
+++ b/src/AvantiPoint.Packages.Registry.Npm/NpmMirrorService.cs
@@ -1,0 +1,103 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using AvantiPoint.Feed.Platform;
+using AvantiPoint.Feed.Platform.Configuration;
+using AvantiPoint.Feed.Platform.Mirror;
+using AvantiPoint.Packages.Core;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace AvantiPoint.Packages.Registry.Npm;
+
+public interface INpmMirrorService
+{
+    Task<JsonObject?> FetchPackumentAsync(string packageName, CancellationToken cancellationToken = default);
+
+    Task<Stream?> FetchTarballAsync(string tarballUrl, CancellationToken cancellationToken = default);
+
+    MirrorCachingStrategy Strategy { get; }
+
+    PackageOrigin MirrorOrigin { get; }
+}
+
+public sealed class NpmMirrorService : INpmMirrorService
+{
+    private readonly NpmFeedOptions _options;
+    private readonly IMirrorPolicyService _policy;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<NpmMirrorService> _logger;
+
+    public NpmMirrorService(
+        IOptions<NpmFeedOptions> options,
+        IMirrorPolicyService policy,
+        IHttpClientFactory httpClientFactory,
+        ILogger<NpmMirrorService> logger)
+    {
+        _options = options.Value;
+        _policy = policy;
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+        Strategy = _policy.GetStrategy(FeedProtocol.Npm);
+        MirrorOrigin = Strategy == MirrorCachingStrategy.ProxyOnly
+            ? PackageOrigin.Cached
+            : PackageOrigin.Mirrored;
+    }
+
+    public MirrorCachingStrategy Strategy { get; }
+
+    public PackageOrigin MirrorOrigin { get; }
+
+    public async Task<JsonObject?> FetchPackumentAsync(string packageName, CancellationToken cancellationToken = default)
+    {
+        var upstreamUrl = BuildUpstreamPackumentUrl(packageName);
+        if (upstreamUrl is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            using var client = _httpClientFactory.CreateClient(nameof(NpmMirrorService));
+            var packument = await client.GetFromJsonAsync<JsonObject>(upstreamUrl, cancellationToken);
+            return packument;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to fetch npm packument {Package} from upstream", packageName);
+            return null;
+        }
+    }
+
+    public async Task<Stream?> FetchTarballAsync(string tarballUrl, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            using var client = _httpClientFactory.CreateClient(nameof(NpmMirrorService));
+            var response = await client.GetAsync(tarballUrl, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+            if (!response.IsSuccessStatusCode)
+            {
+                return null;
+            }
+
+            var bytes = await response.Content.ReadAsByteArrayAsync(cancellationToken);
+            return new MemoryStream(bytes);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to fetch npm tarball from {Url}", tarballUrl);
+            return null;
+        }
+    }
+
+    private string? BuildUpstreamPackumentUrl(string normalizedName)
+    {
+        var baseUrl = _options.Mirror?.RegistryUrl?.TrimEnd('/');
+        if (string.IsNullOrEmpty(baseUrl))
+        {
+            return null;
+        }
+
+        return $"{baseUrl}/{NpmPackageService.EncodePackagePath(normalizedName)}";
+    }
+}

--- a/src/AvantiPoint.Packages.Registry.Npm/NpmMirrorService.cs
+++ b/src/AvantiPoint.Packages.Registry.Npm/NpmMirrorService.cs
@@ -39,9 +39,9 @@ public sealed class NpmMirrorService : INpmMirrorService
         _httpClientFactory = httpClientFactory;
         _logger = logger;
         Strategy = _policy.GetStrategy(FeedProtocol.Npm);
-        MirrorOrigin = Strategy == MirrorCachingStrategy.ProxyOnly
-            ? PackageOrigin.Cached
-            : PackageOrigin.Mirrored;
+        MirrorOrigin = Strategy == MirrorCachingStrategy.IndexAndCache
+            ? PackageOrigin.Mirrored
+            : PackageOrigin.Cached;
     }
 
     public MirrorCachingStrategy Strategy { get; }

--- a/src/AvantiPoint.Packages.Registry.Npm/NpmPackageService.cs
+++ b/src/AvantiPoint.Packages.Registry.Npm/NpmPackageService.cs
@@ -72,6 +72,7 @@ public sealed class NpmPackageService : INpmPackageService
         string feedId,
         string packageName,
         string tarballFileName,
+        Uri publicBaseUrl,
         CancellationToken cancellationToken = default)
     {
         var normalizedName = NormalizePackageName(packageName);
@@ -86,7 +87,7 @@ public sealed class NpmPackageService : INpmPackageService
             await TryMirrorPackumentAsync(
                 feedId,
                 normalizedName,
-                new Uri("http://localhost/npm/"),
+                publicBaseUrl,
                 cancellationToken);
 
             package = await _context.NpmPackages

--- a/src/AvantiPoint.Packages.Registry.Npm/NpmPackageService.cs
+++ b/src/AvantiPoint.Packages.Registry.Npm/NpmPackageService.cs
@@ -283,11 +283,13 @@ public sealed class NpmPackageService : INpmPackageService
         await PublishAsync(feedId, packageName, version, tarball, versionMetadata, publicBaseUrl, cancellationToken);
 
         var normalizedName = NormalizePackageName(packageName);
+        var expectedTarballPath = $"{EncodePackagePath(normalizedName)}/-/{GetTarballFileName(normalizedName, version)}";
         var versionEntity = await _context.NpmVersions
             .FirstOrDefaultAsync(
                 v => v.FeedId == feedId
+                     && v.Package.Name == normalizedName
                      && v.Version == version
-                     && v.TarballPath.Contains(GetTarballFileName(normalizedName, version), StringComparison.Ordinal),
+                     && v.TarballPath == expectedTarballPath,
                 cancellationToken);
 
         if (versionEntity is not null)

--- a/src/AvantiPoint.Packages.Registry.Npm/NpmPackageService.cs
+++ b/src/AvantiPoint.Packages.Registry.Npm/NpmPackageService.cs
@@ -1,11 +1,15 @@
 using System.Security.Cryptography;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using AvantiPoint.Feed.Platform;
+using AvantiPoint.Feed.Platform.Mirror;
 using AvantiPoint.Feed.Platform.Storage;
 using AvantiPoint.Packages.Core;
 using AvantiPoint.Packages.Core.Entities.Npm;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using AvantiPoint.Feed.Platform.Configuration;
 
 namespace AvantiPoint.Packages.Registry.Npm;
 
@@ -19,15 +23,24 @@ public sealed class NpmPackageService : INpmPackageService
 
     private readonly IContext _context;
     private readonly IPathBlobStore _blobStore;
+    private readonly INpmMirrorService _mirror;
+    private readonly IMirrorPolicyService _policy;
+    private readonly NpmFeedOptions _npmOptions;
     private readonly ILogger<NpmPackageService> _logger;
 
     public NpmPackageService(
         IContext context,
         IStorageBackendFactory storageFactory,
+        INpmMirrorService mirror,
+        IMirrorPolicyService policy,
+        IOptions<NpmFeedOptions> npmOptions,
         ILogger<NpmPackageService> logger)
     {
         _context = context;
         _blobStore = storageFactory.CreatePathStore("npm/");
+        _mirror = mirror;
+        _policy = policy;
+        _npmOptions = npmOptions.Value;
         _logger = logger;
     }
 
@@ -48,7 +61,8 @@ public sealed class NpmPackageService : INpmPackageService
 
         if (package is null)
         {
-            return null;
+            var mirrored = await TryMirrorPackumentAsync(feedId, normalizedName, publicBaseUrl, cancellationToken);
+            return mirrored;
         }
 
         return BuildPackument(package, publicBaseUrl);
@@ -65,12 +79,26 @@ public sealed class NpmPackageService : INpmPackageService
             .AsNoTracking()
             .FirstOrDefaultAsync(p => p.FeedId == feedId && p.Name == normalizedName, cancellationToken);
 
+        var expectedTarballPath = $"{EncodePackagePath(normalizedName)}/-/{tarballFileName}";
+
         if (package is null)
         {
-            return null;
+            await TryMirrorPackumentAsync(
+                feedId,
+                normalizedName,
+                new Uri("http://localhost/npm/"),
+                cancellationToken);
+
+            package = await _context.NpmPackages
+                .AsNoTracking()
+                .FirstOrDefaultAsync(p => p.FeedId == feedId && p.Name == normalizedName, cancellationToken);
+
+            if (package is null)
+            {
+                return null;
+            }
         }
 
-        var expectedTarballPath = $"{EncodePackagePath(normalizedName)}/-/{tarballFileName}";
         var version = await _context.NpmVersions
             .AsNoTracking()
             .FirstOrDefaultAsync(
@@ -84,7 +112,148 @@ public sealed class NpmPackageService : INpmPackageService
             return null;
         }
 
-        return await _blobStore.GetAsync(version.TarballPath, cancellationToken);
+        var stream = await _blobStore.GetAsync(version.TarballPath, cancellationToken);
+        if (stream is not null)
+        {
+            return stream;
+        }
+
+        if (_mirror.Strategy == MirrorCachingStrategy.ProxyOnly)
+        {
+            var versionJson = JsonNode.Parse(version.PackumentJson)?.AsObject();
+            var tarballUrl = versionJson?["dist"]?["tarball"]?.GetValue<string>();
+            if (!string.IsNullOrEmpty(tarballUrl))
+            {
+                return await _mirror.FetchTarballAsync(tarballUrl, cancellationToken);
+            }
+        }
+
+        return null;
+    }
+
+    public async Task<NpmSearchResult> SearchAsync(
+        string feedId,
+        string? query,
+        int from,
+        int size,
+        CancellationToken cancellationToken = default)
+    {
+        var packages = _context.NpmPackages.AsNoTracking().Where(p => p.FeedId == feedId);
+
+        if (!string.IsNullOrWhiteSpace(query))
+        {
+            var term = query.Trim();
+            packages = packages.Where(p => EF.Functions.Like(p.Name, $"%{term}%"));
+        }
+
+        var versions = _context.NpmVersions.AsNoTracking().Where(v => v.FeedId == feedId);
+        var joined = packages
+            .Select(p => new
+            {
+                p.Name,
+                Latest = p.Versions
+                    .OrderByDescending(v => v.Published)
+                    .Select(v => new { v.Version, v.Published, v.Origin, v.PackumentJson })
+                    .FirstOrDefault(),
+            })
+            .Where(x => x.Latest != null);
+
+        var rows = await joined.ToListAsync(cancellationToken);
+        var visible = rows
+            .Where(r => _policy.IncludeInDiscovery(FeedProtocol.Npm, r.Latest!.Origin))
+            .Skip(from)
+            .Take(size)
+            .ToList();
+
+        var objects = visible.Select(r =>
+        {
+            var meta = JsonNode.Parse(r.Latest!.PackumentJson)?.AsObject();
+            return new NpmSearchObject(
+                r.Name,
+                r.Latest.Version,
+                meta?["description"]?.GetValue<string>(),
+                r.Latest.Published);
+        }).ToList();
+
+        var total = rows.Count(r => _policy.IncludeInDiscovery(FeedProtocol.Npm, r.Latest!.Origin));
+        return new NpmSearchResult(total, objects);
+    }
+
+    private async Task<JsonObject?> TryMirrorPackumentAsync(
+        string feedId,
+        string normalizedName,
+        Uri publicBaseUrl,
+        CancellationToken cancellationToken)
+    {
+        if (_mirror.Strategy == MirrorCachingStrategy.ProxyOnly)
+        {
+            return await _mirror.FetchPackumentAsync(normalizedName, cancellationToken);
+        }
+
+        var upstream = await _mirror.FetchPackumentAsync(normalizedName, cancellationToken);
+        if (upstream is null)
+        {
+            return null;
+        }
+
+        var versions = upstream["versions"] as JsonObject;
+        if (versions is null)
+        {
+            return null;
+        }
+
+        foreach (var entry in versions)
+        {
+            if (entry.Value is not JsonObject versionJson)
+            {
+                continue;
+            }
+
+            var version = entry.Key;
+            var tarballUrl = versionJson["dist"]?["tarball"]?.GetValue<string>();
+            if (string.IsNullOrEmpty(tarballUrl))
+            {
+                continue;
+            }
+
+            await using var tarball = await _mirror.FetchTarballAsync(tarballUrl, cancellationToken);
+            if (tarball is null)
+            {
+                continue;
+            }
+
+            versionJson["version"] = version;
+            versionJson["name"] = normalizedName;
+            await PublishMirroredAsync(feedId, normalizedName, version, tarball, versionJson, publicBaseUrl, cancellationToken);
+        }
+
+        return await GetPackumentAsync(feedId, normalizedName, publicBaseUrl, cancellationToken);
+    }
+
+    private async Task PublishMirroredAsync(
+        string feedId,
+        string packageName,
+        string version,
+        Stream tarball,
+        JsonObject versionMetadata,
+        Uri publicBaseUrl,
+        CancellationToken cancellationToken)
+    {
+        await PublishAsync(feedId, packageName, version, tarball, versionMetadata, publicBaseUrl, cancellationToken);
+
+        var normalizedName = NormalizePackageName(packageName);
+        var versionEntity = await _context.NpmVersions
+            .FirstOrDefaultAsync(
+                v => v.FeedId == feedId
+                     && v.Version == version
+                     && v.TarballPath.Contains(GetTarballFileName(normalizedName, version), StringComparison.Ordinal),
+                cancellationToken);
+
+        if (versionEntity is not null)
+        {
+            versionEntity.Origin = _mirror.MirrorOrigin;
+            await _context.SaveChangesAsync(cancellationToken);
+        }
     }
 
     public async Task PublishAsync(
@@ -189,7 +358,7 @@ public sealed class NpmPackageService : INpmPackageService
         }
     }
 
-    private static JsonObject BuildPackument(NpmPackage package, Uri publicBaseUrl)
+    internal static JsonObject BuildPackument(NpmPackage package, Uri publicBaseUrl)
     {
         var packument = new JsonObject
         {

--- a/src/AvantiPoint.Packages.Registry.Npm/NpmPackageService.cs
+++ b/src/AvantiPoint.Packages.Registry.Npm/NpmPackageService.cs
@@ -228,7 +228,47 @@ public sealed class NpmPackageService : INpmPackageService
             await PublishMirroredAsync(feedId, normalizedName, version, tarball, versionJson, publicBaseUrl, cancellationToken);
         }
 
+        await ApplyUpstreamDistTagsAsync(feedId, normalizedName, upstream, cancellationToken);
+
         return await GetPackumentAsync(feedId, normalizedName, publicBaseUrl, cancellationToken);
+    }
+
+    private async Task ApplyUpstreamDistTagsAsync(
+        string feedId,
+        string normalizedName,
+        JsonObject upstream,
+        CancellationToken cancellationToken)
+    {
+        if (upstream["dist-tags"] is not JsonObject upstreamTags)
+        {
+            return;
+        }
+
+        var package = await _context.NpmPackages
+            .Include(p => p.DistTags)
+            .Include(p => p.Versions)
+            .FirstOrDefaultAsync(
+                p => p.FeedId == feedId && p.Name == normalizedName,
+                cancellationToken);
+
+        if (package is null)
+        {
+            return;
+        }
+
+        foreach (var entry in upstreamTags)
+        {
+            var version = entry.Value?.GetValue<string>();
+            if (string.IsNullOrEmpty(version)
+                || package.Versions.All(v => v.Version != version))
+            {
+                continue;
+            }
+
+            UpsertDistTag(package, entry.Key, version, feedId);
+        }
+
+        await _context.SaveChangesAsync(cancellationToken);
     }
 
     private async Task PublishMirroredAsync(

--- a/src/AvantiPoint.Packages.Registry.Npm/NpmPackageService.cs
+++ b/src/AvantiPoint.Packages.Registry.Npm/NpmPackageService.cs
@@ -376,10 +376,21 @@ public sealed class NpmPackageService : INpmPackageService
         var tarballUrl = BuildTarballUrl(publicBaseUrl, normalizedName, tarballFileName);
 
         using var sha1 = SHA1.Create();
-        await using var hashingStream = new CryptoStream(tarball, sha1, CryptoStreamMode.Read);
+        var temporaryTarballPath = Path.GetTempFileName();
         var storagePath = $"{EncodePackagePath(normalizedName)}/-/{tarballFileName}";
-        await _blobStore.PutAsync(storagePath, hashingStream, cancellationToken);
-        var shasum = Convert.ToHexString(sha1.Hash!).ToLowerInvariant();
+        await using var bufferedTarball = new FileStream(
+            temporaryTarballPath,
+            FileMode.Create,
+            FileAccess.ReadWrite,
+            FileShare.None,
+            bufferSize: 81920,
+            FileOptions.Asynchronous | FileOptions.DeleteOnClose);
+        await tarball.CopyToAsync(bufferedTarball, cancellationToken);
+        bufferedTarball.Position = 0;
+        var hash = await sha1.ComputeHashAsync(bufferedTarball, cancellationToken);
+        bufferedTarball.Position = 0;
+        await _blobStore.PutAsync(storagePath, bufferedTarball, cancellationToken);
+        var shasum = Convert.ToHexString(hash).ToLowerInvariant();
 
         var package = await _context.NpmPackages
             .Include(p => p.Versions)
@@ -431,6 +442,7 @@ public sealed class NpmPackageService : INpmPackageService
             versionEntity.TarballPath = storagePath;
             versionEntity.Shasum = shasum;
             versionEntity.PackumentJson = versionJson.ToJsonString(JsonOptions);
+            versionEntity.Origin = PackageOrigin.Published;
         }
 
         UpsertDistTag(package, "latest", version, feedId);

--- a/src/AvantiPoint.Packages.Registry.Npm/NpmPackageService.cs
+++ b/src/AvantiPoint.Packages.Registry.Npm/NpmPackageService.cs
@@ -84,6 +84,11 @@ public sealed class NpmPackageService : INpmPackageService
 
         if (package is null)
         {
+            if (_mirror.Strategy == MirrorCachingStrategy.ProxyOnly)
+            {
+                return await FetchProxyOnlyTarballAsync(normalizedName, tarballFileName, cancellationToken);
+            }
+
             await TryMirrorPackumentAsync(
                 feedId,
                 normalizedName,
@@ -246,7 +251,49 @@ public sealed class NpmPackageService : INpmPackageService
 
         await ApplyUpstreamDistTagsAsync(feedId, normalizedName, upstream, cancellationToken);
 
-        return await GetPackumentAsync(feedId, normalizedName, publicBaseUrl, cancellationToken);
+        var package = await _context.NpmPackages
+            .AsNoTracking()
+            .Include(p => p.Versions)
+            .Include(p => p.DistTags)
+            .FirstOrDefaultAsync(
+                p => p.FeedId == feedId && p.Name == normalizedName,
+                cancellationToken);
+
+        return package is null ? null : BuildPackument(package, publicBaseUrl);
+    }
+
+    private async Task<Stream?> FetchProxyOnlyTarballAsync(
+        string normalizedName,
+        string tarballFileName,
+        CancellationToken cancellationToken)
+    {
+        var packument = await _mirror.FetchPackumentAsync(normalizedName, cancellationToken);
+        if (packument?["versions"] is not JsonObject versions)
+        {
+            return null;
+        }
+
+        foreach (var entry in versions)
+        {
+            if (entry.Value is not JsonObject versionJson)
+            {
+                continue;
+            }
+
+            var tarballUrl = versionJson["dist"]?["tarball"]?.GetValue<string>();
+            if (string.IsNullOrEmpty(tarballUrl))
+            {
+                continue;
+            }
+
+            if (Uri.TryCreate(tarballUrl, UriKind.Absolute, out var tarballUri)
+                && string.Equals(Path.GetFileName(tarballUri.LocalPath), tarballFileName, StringComparison.OrdinalIgnoreCase))
+            {
+                return await _mirror.FetchTarballAsync(tarballUrl, cancellationToken);
+            }
+        }
+
+        return null;
     }
 
     private async Task ApplyUpstreamDistTagsAsync(

--- a/src/AvantiPoint.Packages.Registry.Npm/NpmPackageService.cs
+++ b/src/AvantiPoint.Packages.Registry.Npm/NpmPackageService.cs
@@ -202,7 +202,9 @@ public sealed class NpmPackageService : INpmPackageService
     {
         if (_mirror.Strategy == MirrorCachingStrategy.ProxyOnly)
         {
-            return await _mirror.FetchPackumentAsync(normalizedName, cancellationToken);
+            var packument = await _mirror.FetchPackumentAsync(normalizedName, cancellationToken);
+            RewritePackumentTarballUrls(packument, publicBaseUrl, normalizedName);
+            return packument;
         }
 
         var upstream = await _mirror.FetchPackumentAsync(normalizedName, cancellationToken);
@@ -441,7 +443,27 @@ public sealed class NpmPackageService : INpmPackageService
         return packument;
     }
 
-    private static void EnsureDistTarballUrl(JsonObject versionJson, Uri publicBaseUrl, string packageName)
+    private static void RewritePackumentTarballUrls(JsonObject? packument, Uri publicBaseUrl, string packageName)
+    {
+        if (packument?["versions"] is not JsonObject versions)
+        {
+            return;
+        }
+
+        foreach (var entry in versions)
+        {
+            if (entry.Value is JsonObject versionJson)
+            {
+                EnsureDistTarballUrl(versionJson, publicBaseUrl, packageName, forceRewrite: true);
+            }
+        }
+    }
+
+    private static void EnsureDistTarballUrl(
+        JsonObject versionJson,
+        Uri publicBaseUrl,
+        string packageName,
+        bool forceRewrite = false)
     {
         if (versionJson["dist"] is not JsonObject dist)
         {
@@ -449,15 +471,30 @@ public sealed class NpmPackageService : INpmPackageService
         }
 
         var tarball = dist["tarball"]?.GetValue<string>();
-        if (string.IsNullOrEmpty(tarball)
-            || tarball.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
-            || tarball.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+        if (string.IsNullOrEmpty(tarball))
         {
             return;
         }
 
-        var fileName = tarball.Contains('/') ? Path.GetFileName(tarball) : tarball;
+        if (!forceRewrite
+            && (tarball.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
+                || tarball.StartsWith("https://", StringComparison.OrdinalIgnoreCase)))
+        {
+            return;
+        }
+
+        var fileName = GetTarballFileNameFromUrl(tarball);
         dist["tarball"] = BuildTarballUrl(publicBaseUrl, packageName, fileName);
+    }
+
+    private static string GetTarballFileNameFromUrl(string tarball)
+    {
+        if (Uri.TryCreate(tarball, UriKind.Absolute, out var uri))
+        {
+            return Path.GetFileName(uri.AbsolutePath);
+        }
+
+        return tarball.Contains('/') ? Path.GetFileName(tarball) : tarball;
     }
 
     internal static string BuildTarballUrl(Uri publicBaseUrl, string packageName, string tarballFileName)

--- a/src/AvantiPoint.Packages.Registry.Npm/NpmPackageService.cs
+++ b/src/AvantiPoint.Packages.Registry.Npm/NpmPackageService.cs
@@ -147,21 +147,17 @@ public sealed class NpmPackageService : INpmPackageService
             packages = packages.Where(p => EF.Functions.Like(p.Name, $"%{term}%"));
         }
 
-        var versions = _context.NpmVersions.AsNoTracking().Where(v => v.FeedId == feedId);
-        var joined = packages
-            .Select(p => new
-            {
-                p.Name,
-                Latest = p.Versions
-                    .OrderByDescending(v => v.Published)
-                    .Select(v => new { v.Version, v.Published, v.Origin, v.PackumentJson })
-                    .FirstOrDefault(),
-            })
-            .Where(x => x.Latest != null);
-
-        var rows = await joined.ToListAsync(cancellationToken);
-        var visible = rows
-            .Where(r => _policy.IncludeInDiscovery(FeedProtocol.Npm, r.Latest!.Origin))
+        var rows = await packages
+            .Include(p => p.Versions)
+            .Include(p => p.DistTags)
+            .AsSplitQuery()
+            .ToListAsync(cancellationToken);
+        var latestRows = rows
+            .Select(r => new { r.Name, Latest = SelectSearchVersion(r.Versions, r.DistTags) })
+            .Where(r => r.Latest is not null)
+            .OrderBy(r => r.Name, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        var visible = latestRows
             .Skip(from)
             .Take(size)
             .ToList();
@@ -176,8 +172,26 @@ public sealed class NpmPackageService : INpmPackageService
                 r.Latest.Published);
         }).ToList();
 
-        var total = rows.Count(r => _policy.IncludeInDiscovery(FeedProtocol.Npm, r.Latest!.Origin));
+        var total = latestRows.Count;
         return new NpmSearchResult(total, objects);
+    }
+
+    private NpmVersion? SelectSearchVersion(IEnumerable<NpmVersion> versions, IEnumerable<NpmDistTag> distTags)
+    {
+        var visibleVersions = versions
+            .Where(v => _policy.IncludeInDiscovery(FeedProtocol.Npm, v.Origin))
+            .ToList();
+        var latestTag = distTags.FirstOrDefault(t => t.Tag == "latest");
+        if (latestTag is not null)
+        {
+            var tagged = visibleVersions.FirstOrDefault(v => v.Version == latestTag.Version);
+            if (tagged is not null)
+            {
+                return tagged;
+            }
+        }
+
+        return visibleVersions.OrderByDescending(v => v.Published).FirstOrDefault();
     }
 
     private async Task<JsonObject?> TryMirrorPackumentAsync(

--- a/src/AvantiPoint.Packages.Registry.Npm/NpmRegistryEndpoints.cs
+++ b/src/AvantiPoint.Packages.Registry.Npm/NpmRegistryEndpoints.cs
@@ -19,6 +19,8 @@ public static class NpmRegistryEndpoints
 {
     public static IServiceCollection AddNpmRegistry(this IServiceCollection services)
     {
+        services.AddHttpClient(nameof(NpmMirrorService));
+        services.AddScoped<INpmMirrorService, NpmMirrorService>();
         services.AddScoped<INpmPackageService, NpmPackageService>();
         return services;
     }
@@ -51,8 +53,32 @@ public static class NpmRegistryEndpoints
         return Results.Json(new { username = surface?.SurfaceId ?? "npm" });
     }
 
-    private static IResult Search() =>
-        Results.Json(new { objects = Array.Empty<object>() });
+    private static async Task<IResult> Search(
+        HttpRequest request,
+        INpmPackageService service,
+        ISurfaceContextAccessor surfaceAccessor,
+        CancellationToken cancellationToken)
+    {
+        var query = request.Query["text"].FirstOrDefault();
+        var from = int.TryParse(request.Query["from"].FirstOrDefault(), out var f) ? f : 0;
+        var size = int.TryParse(request.Query["size"].FirstOrDefault(), out var s) ? s : 20;
+
+        var surface = surfaceAccessor.Current!;
+        var result = await service.SearchAsync(surface.FeedId, query, from, size, cancellationToken);
+
+        var objects = result.Objects.Select(o => new
+        {
+            package = new
+            {
+                name = o.Name,
+                version = o.Version,
+                description = o.Description,
+                date = o.Published?.ToString("o"),
+            },
+        });
+
+        return Results.Json(new { total = result.Total, objects });
+    }
 
     private static IResult LoginStub() =>
         Results.Json(new

--- a/src/AvantiPoint.Packages.Registry.Npm/NpmRegistryEndpoints.cs
+++ b/src/AvantiPoint.Packages.Registry.Npm/NpmRegistryEndpoints.cs
@@ -60,8 +60,8 @@ public static class NpmRegistryEndpoints
         CancellationToken cancellationToken)
     {
         var query = request.Query["text"].FirstOrDefault();
-        var from = int.TryParse(request.Query["from"].FirstOrDefault(), out var f) ? f : 0;
-        var size = int.TryParse(request.Query["size"].FirstOrDefault(), out var s) ? s : 20;
+        var from = Math.Max(0, int.TryParse(request.Query["from"].FirstOrDefault(), out var f) ? f : 0);
+        var size = Math.Max(0, int.TryParse(request.Query["size"].FirstOrDefault(), out var s) ? s : 20);
 
         var surface = surfaceAccessor.Current!;
         var result = await service.SearchAsync(surface.FeedId, query, from, size, cancellationToken);

--- a/src/AvantiPoint.Packages.Registry.Npm/NpmRegistryEndpoints.cs
+++ b/src/AvantiPoint.Packages.Registry.Npm/NpmRegistryEndpoints.cs
@@ -148,6 +148,7 @@ public static class NpmRegistryEndpoints
             surface.FeedId,
             packagePath,
             tarball,
+            surface.PublicBaseUrl,
             cancellationToken);
 
         if (stream is null)

--- a/src/AvantiPoint.Packages.Registry.Oci/IOciMirrorService.cs
+++ b/src/AvantiPoint.Packages.Registry.Oci/IOciMirrorService.cs
@@ -1,0 +1,30 @@
+using AvantiPoint.Feed.Platform;
+using AvantiPoint.Feed.Platform.Mirror;
+using AvantiPoint.Packages.Core;
+
+namespace AvantiPoint.Packages.Registry.Oci;
+
+public interface IOciMirrorService
+{
+    Task<OciUpstreamManifest?> TryFetchManifestAsync(
+        SurfaceContext surface,
+        string repositoryName,
+        string reference,
+        CancellationToken cancellationToken = default);
+
+    Task<Stream?> TryFetchBlobAsync(
+        SurfaceContext surface,
+        string repositoryName,
+        string digest,
+        CancellationToken cancellationToken = default);
+
+    Task<OciBlobExistsResult?> TryCheckBlobExistsAsync(
+        SurfaceContext surface,
+        string repositoryName,
+        string digest,
+        CancellationToken cancellationToken = default);
+
+    PackageOrigin MirrorOrigin(SurfaceContext surface);
+    MirrorCachingStrategy Strategy(SurfaceContext surface);
+    bool ShouldPersist(SurfaceContext surface);
+}

--- a/src/AvantiPoint.Packages.Registry.Oci/IOciRegistryService.cs
+++ b/src/AvantiPoint.Packages.Registry.Oci/IOciRegistryService.cs
@@ -27,6 +27,7 @@ public interface IOciRegistryService
     Task<OciBlobExistsResult> BlobExistsAsync(
         SurfaceContext surface,
         string digest,
+        string? repositoryName = null,
         CancellationToken cancellationToken = default);
 
     Task<OciStartUploadResult> StartUploadAsync(

--- a/src/AvantiPoint.Packages.Registry.Oci/IOciRegistryService.cs
+++ b/src/AvantiPoint.Packages.Registry.Oci/IOciRegistryService.cs
@@ -21,6 +21,7 @@ public interface IOciRegistryService
     Task<OciBlobResult?> GetBlobAsync(
         SurfaceContext surface,
         string digest,
+        string? repositoryName = null,
         CancellationToken cancellationToken = default);
 
     Task<OciBlobExistsResult> BlobExistsAsync(

--- a/src/AvantiPoint.Packages.Registry.Oci/OciMirrorService.cs
+++ b/src/AvantiPoint.Packages.Registry.Oci/OciMirrorService.cs
@@ -31,9 +31,9 @@ public sealed class OciMirrorService : IOciMirrorService
     }
 
     public PackageOrigin MirrorOrigin(SurfaceContext surface) =>
-        Strategy(surface) == MirrorCachingStrategy.ProxyOnly
-            ? PackageOrigin.Cached
-            : PackageOrigin.Mirrored;
+        Strategy(surface) == MirrorCachingStrategy.IndexAndCache
+            ? PackageOrigin.Mirrored
+            : PackageOrigin.Cached;
 
     public MirrorCachingStrategy Strategy(SurfaceContext surface) =>
         _policy.GetStrategy(FeedProtocol.Oci, surface.OciSegment);

--- a/src/AvantiPoint.Packages.Registry.Oci/OciMirrorService.cs
+++ b/src/AvantiPoint.Packages.Registry.Oci/OciMirrorService.cs
@@ -84,6 +84,8 @@ public sealed class OciMirrorService : IOciMirrorService
         using var request = new HttpRequestMessage(HttpMethod.Get, url);
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.oci.image.manifest.v1+json"));
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.docker.distribution.manifest.v2+json"));
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.oci.image.index.v1+json"));
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.docker.distribution.manifest.list.v2+json"));
 
         using var response = await client.SendAsync(request, cancellationToken);
         if (!response.IsSuccessStatusCode)

--- a/src/AvantiPoint.Packages.Registry.Oci/OciMirrorService.cs
+++ b/src/AvantiPoint.Packages.Registry.Oci/OciMirrorService.cs
@@ -1,0 +1,157 @@
+using System.Net.Http.Headers;
+using AvantiPoint.Feed.Platform;
+using AvantiPoint.Feed.Platform.Configuration;
+using AvantiPoint.Feed.Platform.Mirror;
+using AvantiPoint.Feed.Platform.Storage;
+using AvantiPoint.Packages.Core;
+using Microsoft.Extensions.Logging;
+
+namespace AvantiPoint.Packages.Registry.Oci;
+
+public interface IOciMirrorService
+{
+    Task<OciUpstreamManifest?> TryFetchManifestAsync(
+        SurfaceContext surface,
+        string repositoryName,
+        string reference,
+        CancellationToken cancellationToken = default);
+
+    Task<Stream?> TryFetchBlobAsync(
+        SurfaceContext surface,
+        string repositoryName,
+        string digest,
+        CancellationToken cancellationToken = default);
+
+    PackageOrigin MirrorOrigin(SurfaceContext surface);
+
+    MirrorCachingStrategy Strategy(SurfaceContext surface);
+
+    bool ShouldPersist(SurfaceContext surface);
+}
+
+public sealed record OciUpstreamManifest(string Digest, string MediaType, byte[] Content);
+
+public sealed class OciMirrorService : IOciMirrorService
+{
+    private readonly OciFeedOptionsAccessor _optionsAccessor;
+    private readonly IMirrorPolicyService _policy;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<OciMirrorService> _logger;
+
+    public OciMirrorService(
+        OciFeedOptionsAccessor optionsAccessor,
+        IMirrorPolicyService policy,
+        IHttpClientFactory httpClientFactory,
+        ILogger<OciMirrorService> logger)
+    {
+        _optionsAccessor = optionsAccessor;
+        _policy = policy;
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+    }
+
+    public PackageOrigin MirrorOrigin(SurfaceContext surface) =>
+        Strategy(surface) == MirrorCachingStrategy.ProxyOnly
+            ? PackageOrigin.Cached
+            : PackageOrigin.Mirrored;
+
+    public MirrorCachingStrategy Strategy(SurfaceContext surface) =>
+        _policy.GetStrategy(FeedProtocol.Oci, surface.OciSegment);
+
+    public bool ShouldPersist(SurfaceContext surface) =>
+        Strategy(surface) != MirrorCachingStrategy.ProxyOnly;
+
+    public async Task<OciUpstreamManifest?> TryFetchManifestAsync(
+        SurfaceContext surface,
+        string repositoryName,
+        string reference,
+        CancellationToken cancellationToken = default)
+    {
+        var upstream = GetUpstreamBaseUrl(surface);
+        if (upstream is null)
+        {
+            return null;
+        }
+
+        var url = $"{upstream}/v2/{repositoryName}/manifests/{reference}";
+        using var client = CreateClient(surface);
+        using var request = new HttpRequestMessage(HttpMethod.Get, url);
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.oci.image.manifest.v1+json"));
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.docker.distribution.manifest.v2+json"));
+
+        using var response = await client.SendAsync(request, cancellationToken);
+        if (!response.IsSuccessStatusCode)
+        {
+            return null;
+        }
+
+        var mediaType = response.Content.Headers.ContentType?.MediaType ?? "application/vnd.oci.image.manifest.v1+json";
+        var digest = response.Headers.TryGetValues("Docker-Content-Digest", out var values)
+            ? values.First()
+            : null;
+        var bytes = await response.Content.ReadAsByteArrayAsync(cancellationToken);
+        if (string.IsNullOrEmpty(digest))
+        {
+            using var buffer = new MemoryStream(bytes);
+            digest = await DigestBlobStore.ComputeSha256DigestAsync(buffer, cancellationToken);
+        }
+
+        return new OciUpstreamManifest(digest, mediaType, bytes);
+    }
+
+    public async Task<Stream?> TryFetchBlobAsync(
+        SurfaceContext surface,
+        string repositoryName,
+        string digest,
+        CancellationToken cancellationToken = default)
+    {
+        var upstream = GetUpstreamBaseUrl(surface);
+        if (upstream is null)
+        {
+            return null;
+        }
+
+        var url = $"{upstream}/v2/{repositoryName}/blobs/{digest}";
+
+        using var client = CreateClient(surface);
+        using var response = await client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+        if (!response.IsSuccessStatusCode)
+        {
+            _logger.LogDebug("Upstream OCI blob {Digest} not found at {Url}", digest, url);
+            return null;
+        }
+
+        var bytes = await response.Content.ReadAsByteArrayAsync(cancellationToken);
+        return new MemoryStream(bytes);
+    }
+
+    private string? GetUpstreamBaseUrl(SurfaceContext surface)
+    {
+        var options = _optionsAccessor.GetOptions(surface);
+        var registry = options.Mirror?.Registries?
+            .Where(r => !string.IsNullOrWhiteSpace(r.Url))
+            .OrderBy(r => r.Priority)
+            .FirstOrDefault();
+
+        return registry?.Url?.TrimEnd('/');
+    }
+
+    private HttpClient CreateClient(SurfaceContext surface)
+    {
+        var client = _httpClientFactory.CreateClient(nameof(OciMirrorService));
+        var options = _optionsAccessor.GetOptions(surface);
+        var registry = options.Mirror?.Registries?
+            .Where(r => !string.IsNullOrWhiteSpace(r.Url))
+            .OrderBy(r => r.Priority)
+            .FirstOrDefault();
+
+        if (registry?.Username is not null && registry.Password is not null)
+        {
+            var credentials = Convert.ToBase64String(
+                System.Text.Encoding.UTF8.GetBytes($"{registry.Username}:{registry.Password}"));
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", credentials);
+        }
+
+        return client;
+    }
+}

--- a/src/AvantiPoint.Packages.Registry.Oci/OciMirrorService.cs
+++ b/src/AvantiPoint.Packages.Registry.Oci/OciMirrorService.cs
@@ -22,6 +22,12 @@ public interface IOciMirrorService
         string digest,
         CancellationToken cancellationToken = default);
 
+    Task<OciBlobExistsResult?> TryCheckBlobExistsAsync(
+        SurfaceContext surface,
+        string repositoryName,
+        string digest,
+        CancellationToken cancellationToken = default);
+
     PackageOrigin MirrorOrigin(SurfaceContext surface);
 
     MirrorCachingStrategy Strategy(SurfaceContext surface);
@@ -123,6 +129,33 @@ public sealed class OciMirrorService : IOciMirrorService
 
         var bytes = await response.Content.ReadAsByteArrayAsync(cancellationToken);
         return new MemoryStream(bytes);
+    }
+
+    public async Task<OciBlobExistsResult?> TryCheckBlobExistsAsync(
+        SurfaceContext surface,
+        string repositoryName,
+        string digest,
+        CancellationToken cancellationToken = default)
+    {
+        var upstream = GetUpstreamBaseUrl(surface);
+        if (upstream is null)
+        {
+            return null;
+        }
+
+        var url = $"{upstream}/v2/{repositoryName}/blobs/{digest}";
+
+        using var client = CreateClient(surface);
+        using var request = new HttpRequestMessage(HttpMethod.Head, url);
+        using var response = await client.SendAsync(request, cancellationToken);
+        if (!response.IsSuccessStatusCode)
+        {
+            _logger.LogDebug("Upstream OCI blob {Digest} not found at {Url}", digest, url);
+            return new OciBlobExistsResult(false, 0);
+        }
+
+        var size = response.Content.Headers.ContentLength ?? 0;
+        return new OciBlobExistsResult(true, size);
     }
 
     private string? GetUpstreamBaseUrl(SurfaceContext surface)

--- a/src/AvantiPoint.Packages.Registry.Oci/OciMirrorService.cs
+++ b/src/AvantiPoint.Packages.Registry.Oci/OciMirrorService.cs
@@ -47,38 +47,38 @@ public sealed class OciMirrorService : IOciMirrorService
         string reference,
         CancellationToken cancellationToken = default)
     {
-        var upstream = GetUpstreamBaseUrl(surface);
-        if (upstream is null)
+        foreach (var registry in GetUpstreamRegistries(surface))
         {
-            return null;
+            var url = $"{registry.Url}/v2/{repositoryName}/manifests/{reference}";
+            var client = CreateClient(registry);
+            using var request = CreateManifestRequest(url);
+
+            using var response = await SendWithBearerChallengeAsync(
+                client,
+                request,
+                () => CreateManifestRequest(url),
+                cancellationToken);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogDebug("Upstream OCI manifest {RepositoryName}:{Reference} not found at {Url}", repositoryName, reference, url);
+                continue;
+            }
+
+            var mediaType = response.Content.Headers.ContentType?.MediaType ?? "application/vnd.oci.image.manifest.v1+json";
+            var digest = response.Headers.TryGetValues("Docker-Content-Digest", out var values)
+                ? values.First()
+                : null;
+            var bytes = await response.Content.ReadAsByteArrayAsync(cancellationToken);
+            if (string.IsNullOrEmpty(digest))
+            {
+                using var buffer = new MemoryStream(bytes);
+                digest = await DigestBlobStore.ComputeSha256DigestAsync(buffer, cancellationToken);
+            }
+
+            return new OciUpstreamManifest(digest, mediaType, bytes);
         }
 
-        var url = $"{upstream}/v2/{repositoryName}/manifests/{reference}";
-        using var client = CreateClient(surface);
-        using var request = CreateManifestRequest(url);
-
-        using var response = await SendWithBearerChallengeAsync(
-            client,
-            request,
-            () => CreateManifestRequest(url),
-            cancellationToken);
-        if (!response.IsSuccessStatusCode)
-        {
-            return null;
-        }
-
-        var mediaType = response.Content.Headers.ContentType?.MediaType ?? "application/vnd.oci.image.manifest.v1+json";
-        var digest = response.Headers.TryGetValues("Docker-Content-Digest", out var values)
-            ? values.First()
-            : null;
-        var bytes = await response.Content.ReadAsByteArrayAsync(cancellationToken);
-        if (string.IsNullOrEmpty(digest))
-        {
-            using var buffer = new MemoryStream(bytes);
-            digest = await DigestBlobStore.ComputeSha256DigestAsync(buffer, cancellationToken);
-        }
-
-        return new OciUpstreamManifest(digest, mediaType, bytes);
+        return null;
     }
 
     public async Task<Stream?> TryFetchBlobAsync(
@@ -87,30 +87,29 @@ public sealed class OciMirrorService : IOciMirrorService
         string digest,
         CancellationToken cancellationToken = default)
     {
-        var upstream = GetUpstreamBaseUrl(surface);
-        if (upstream is null)
+        foreach (var registry in GetUpstreamRegistries(surface))
         {
-            return null;
+            var url = $"{registry.Url}/v2/{repositoryName}/blobs/{digest}";
+
+            var client = CreateClient(registry);
+            using var request = new HttpRequestMessage(HttpMethod.Get, url);
+            using var response = await SendWithBearerChallengeAsync(
+                client,
+                request,
+                () => new HttpRequestMessage(HttpMethod.Get, url),
+                cancellationToken,
+                HttpCompletionOption.ResponseHeadersRead);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogDebug("Upstream OCI blob {Digest} not found at {Url}", digest, url);
+                continue;
+            }
+
+            var bytes = await response.Content.ReadAsByteArrayAsync(cancellationToken);
+            return new MemoryStream(bytes);
         }
 
-        var url = $"{upstream}/v2/{repositoryName}/blobs/{digest}";
-
-        using var client = CreateClient(surface);
-        using var request = new HttpRequestMessage(HttpMethod.Get, url);
-        using var response = await SendWithBearerChallengeAsync(
-            client,
-            request,
-            () => new HttpRequestMessage(HttpMethod.Get, url),
-            cancellationToken,
-            HttpCompletionOption.ResponseHeadersRead);
-        if (!response.IsSuccessStatusCode)
-        {
-            _logger.LogDebug("Upstream OCI blob {Digest} not found at {Url}", digest, url);
-            return null;
-        }
-
-        var bytes = await response.Content.ReadAsByteArrayAsync(cancellationToken);
-        return new MemoryStream(bytes);
+        return null;
     }
 
     public async Task<OciBlobExistsResult?> TryCheckBlobExistsAsync(
@@ -119,52 +118,46 @@ public sealed class OciMirrorService : IOciMirrorService
         string digest,
         CancellationToken cancellationToken = default)
     {
-        var upstream = GetUpstreamBaseUrl(surface);
-        if (upstream is null)
+        foreach (var registry in GetUpstreamRegistries(surface))
         {
-            return null;
+            var url = $"{registry.Url}/v2/{repositoryName}/blobs/{digest}";
+
+            var client = CreateClient(registry);
+            using var request = new HttpRequestMessage(HttpMethod.Head, url);
+            using var response = await SendWithBearerChallengeAsync(
+                client,
+                request,
+                () => new HttpRequestMessage(HttpMethod.Head, url),
+                cancellationToken);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogDebug("Upstream OCI blob {Digest} not found at {Url}", digest, url);
+                continue;
+            }
+
+            var size = response.Content.Headers.ContentLength ?? 0;
+            return new OciBlobExistsResult(true, size);
         }
 
-        var url = $"{upstream}/v2/{repositoryName}/blobs/{digest}";
-
-        using var client = CreateClient(surface);
-        using var request = new HttpRequestMessage(HttpMethod.Head, url);
-        using var response = await SendWithBearerChallengeAsync(
-            client,
-            request,
-            () => new HttpRequestMessage(HttpMethod.Head, url),
-            cancellationToken);
-        if (!response.IsSuccessStatusCode)
-        {
-            _logger.LogDebug("Upstream OCI blob {Digest} not found at {Url}", digest, url);
-            return new OciBlobExistsResult(false, 0);
-        }
-
-        var size = response.Content.Headers.ContentLength ?? 0;
-        return new OciBlobExistsResult(true, size);
+        return new OciBlobExistsResult(false, 0);
     }
 
-    private string? GetUpstreamBaseUrl(SurfaceContext surface)
+    private IReadOnlyList<OciUpstreamRegistry> GetUpstreamRegistries(SurfaceContext surface)
     {
         var options = _optionsAccessor.GetOptions(surface);
-        var registry = options.Mirror?.Registries?
+        return options.Mirror?.Registries?
             .Where(r => !string.IsNullOrWhiteSpace(r.Url))
             .OrderBy(r => r.Priority)
-            .FirstOrDefault();
-
-        return registry?.Url?.TrimEnd('/');
+            .Select(r => new OciUpstreamRegistry(r.Url.TrimEnd('/'), r.Username, r.Password))
+            .ToArray()
+            ?? [];
     }
 
-    private HttpClient CreateClient(SurfaceContext surface)
+    private HttpClient CreateClient(OciUpstreamRegistry registry)
     {
         var client = _httpClientFactory.CreateClient(nameof(OciMirrorService));
-        var options = _optionsAccessor.GetOptions(surface);
-        var registry = options.Mirror?.Registries?
-            .Where(r => !string.IsNullOrWhiteSpace(r.Url))
-            .OrderBy(r => r.Priority)
-            .FirstOrDefault();
-
-        if (registry?.Username is not null && registry.Password is not null)
+        client.DefaultRequestHeaders.Authorization = null;
+        if (registry.Username is not null && registry.Password is not null)
         {
             var credentials = Convert.ToBase64String(
                 Encoding.UTF8.GetBytes($"{registry.Username}:{registry.Password}"));
@@ -372,4 +365,6 @@ public sealed class OciMirrorService : IOciMirrorService
     }
 
     private readonly record struct OciBearerChallenge(string Realm, string? Service, string? Scope);
+
+    private readonly record struct OciUpstreamRegistry(string Url, string? Username, string? Password);
 }

--- a/src/AvantiPoint.Packages.Registry.Oci/OciMirrorService.cs
+++ b/src/AvantiPoint.Packages.Registry.Oci/OciMirrorService.cs
@@ -1,4 +1,7 @@
+using System.Net;
 using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
 using AvantiPoint.Feed.Platform;
 using AvantiPoint.Feed.Platform.Configuration;
 using AvantiPoint.Feed.Platform.Mirror;
@@ -7,35 +10,6 @@ using AvantiPoint.Packages.Core;
 using Microsoft.Extensions.Logging;
 
 namespace AvantiPoint.Packages.Registry.Oci;
-
-public interface IOciMirrorService
-{
-    Task<OciUpstreamManifest?> TryFetchManifestAsync(
-        SurfaceContext surface,
-        string repositoryName,
-        string reference,
-        CancellationToken cancellationToken = default);
-
-    Task<Stream?> TryFetchBlobAsync(
-        SurfaceContext surface,
-        string repositoryName,
-        string digest,
-        CancellationToken cancellationToken = default);
-
-    Task<OciBlobExistsResult?> TryCheckBlobExistsAsync(
-        SurfaceContext surface,
-        string repositoryName,
-        string digest,
-        CancellationToken cancellationToken = default);
-
-    PackageOrigin MirrorOrigin(SurfaceContext surface);
-
-    MirrorCachingStrategy Strategy(SurfaceContext surface);
-
-    bool ShouldPersist(SurfaceContext surface);
-}
-
-public sealed record OciUpstreamManifest(string Digest, string MediaType, byte[] Content);
 
 public sealed class OciMirrorService : IOciMirrorService
 {
@@ -81,13 +55,13 @@ public sealed class OciMirrorService : IOciMirrorService
 
         var url = $"{upstream}/v2/{repositoryName}/manifests/{reference}";
         using var client = CreateClient(surface);
-        using var request = new HttpRequestMessage(HttpMethod.Get, url);
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.oci.image.manifest.v1+json"));
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.docker.distribution.manifest.v2+json"));
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.oci.image.index.v1+json"));
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.docker.distribution.manifest.list.v2+json"));
+        using var request = CreateManifestRequest(url);
 
-        using var response = await client.SendAsync(request, cancellationToken);
+        using var response = await SendWithBearerChallengeAsync(
+            client,
+            request,
+            () => CreateManifestRequest(url),
+            cancellationToken);
         if (!response.IsSuccessStatusCode)
         {
             return null;
@@ -122,7 +96,13 @@ public sealed class OciMirrorService : IOciMirrorService
         var url = $"{upstream}/v2/{repositoryName}/blobs/{digest}";
 
         using var client = CreateClient(surface);
-        using var response = await client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+        using var request = new HttpRequestMessage(HttpMethod.Get, url);
+        using var response = await SendWithBearerChallengeAsync(
+            client,
+            request,
+            () => new HttpRequestMessage(HttpMethod.Get, url),
+            cancellationToken,
+            HttpCompletionOption.ResponseHeadersRead);
         if (!response.IsSuccessStatusCode)
         {
             _logger.LogDebug("Upstream OCI blob {Digest} not found at {Url}", digest, url);
@@ -149,7 +129,11 @@ public sealed class OciMirrorService : IOciMirrorService
 
         using var client = CreateClient(surface);
         using var request = new HttpRequestMessage(HttpMethod.Head, url);
-        using var response = await client.SendAsync(request, cancellationToken);
+        using var response = await SendWithBearerChallengeAsync(
+            client,
+            request,
+            () => new HttpRequestMessage(HttpMethod.Head, url),
+            cancellationToken);
         if (!response.IsSuccessStatusCode)
         {
             _logger.LogDebug("Upstream OCI blob {Digest} not found at {Url}", digest, url);
@@ -183,10 +167,209 @@ public sealed class OciMirrorService : IOciMirrorService
         if (registry?.Username is not null && registry.Password is not null)
         {
             var credentials = Convert.ToBase64String(
-                System.Text.Encoding.UTF8.GetBytes($"{registry.Username}:{registry.Password}"));
+                Encoding.UTF8.GetBytes($"{registry.Username}:{registry.Password}"));
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", credentials);
         }
 
         return client;
     }
+
+    private static HttpRequestMessage CreateManifestRequest(string url)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, url);
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.oci.image.manifest.v1+json"));
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.docker.distribution.manifest.v2+json"));
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.oci.image.index.v1+json"));
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.docker.distribution.manifest.list.v2+json"));
+        return request;
+    }
+
+    private async Task<HttpResponseMessage> SendWithBearerChallengeAsync(
+        HttpClient client,
+        HttpRequestMessage request,
+        Func<HttpRequestMessage> retryRequestFactory,
+        CancellationToken cancellationToken,
+        HttpCompletionOption completionOption = HttpCompletionOption.ResponseContentRead)
+    {
+        var response = await client.SendAsync(request, completionOption, cancellationToken);
+        if (response.StatusCode != HttpStatusCode.Unauthorized || !TryGetBearerChallenge(response, out var challenge))
+        {
+            return response;
+        }
+
+        var token = await TryFetchBearerTokenAsync(client, challenge, cancellationToken);
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            return response;
+        }
+
+        response.Dispose();
+        using var retryRequest = retryRequestFactory();
+        retryRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return await client.SendAsync(retryRequest, completionOption, cancellationToken);
+    }
+
+    private static bool TryGetBearerChallenge(HttpResponseMessage response, out OciBearerChallenge challenge)
+    {
+        foreach (var header in response.Headers.WwwAuthenticate)
+        {
+            if (!string.Equals(header.Scheme, "Bearer", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var parameters = ParseChallengeParameters(header.Parameter);
+            if (parameters.TryGetValue("realm", out var realm) && !string.IsNullOrWhiteSpace(realm))
+            {
+                parameters.TryGetValue("service", out var service);
+                parameters.TryGetValue("scope", out var scope);
+                challenge = new OciBearerChallenge(realm, service, scope);
+                return true;
+            }
+        }
+
+        challenge = default;
+        return false;
+    }
+
+    private async Task<string?> TryFetchBearerTokenAsync(
+        HttpClient client,
+        OciBearerChallenge challenge,
+        CancellationToken cancellationToken)
+    {
+        var tokenUri = BuildTokenUri(challenge);
+        if (tokenUri is null || !CanRequestToken(client, tokenUri))
+        {
+            return null;
+        }
+
+        using var response = await client.GetAsync(tokenUri, cancellationToken);
+        if (!response.IsSuccessStatusCode)
+        {
+            _logger.LogDebug("Upstream OCI token service returned {StatusCode} for {Realm}", response.StatusCode, challenge.Realm);
+            return null;
+        }
+
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+        using var document = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken);
+        return TryGetStringProperty(document.RootElement, "token")
+            ?? TryGetStringProperty(document.RootElement, "access_token");
+    }
+
+    private static bool CanRequestToken(HttpClient client, Uri tokenUri)
+    {
+        return string.Equals(tokenUri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)
+            || client.DefaultRequestHeaders.Authorization is null;
+    }
+
+    private static Uri? BuildTokenUri(OciBearerChallenge challenge)
+    {
+        if (!Uri.TryCreate(challenge.Realm, UriKind.Absolute, out var realm))
+        {
+            return null;
+        }
+
+        var builder = new UriBuilder(realm);
+        var query = new List<string>();
+        if (!string.IsNullOrWhiteSpace(builder.Query))
+        {
+            query.Add(builder.Query.TrimStart('?'));
+        }
+
+        if (!string.IsNullOrWhiteSpace(challenge.Service))
+        {
+            query.Add($"service={Uri.EscapeDataString(challenge.Service)}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(challenge.Scope))
+        {
+            query.Add($"scope={Uri.EscapeDataString(challenge.Scope)}");
+        }
+
+        builder.Query = string.Join("&", query);
+        return builder.Uri;
+    }
+
+    private static string? TryGetStringProperty(JsonElement element, string propertyName)
+    {
+        return element.TryGetProperty(propertyName, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+    }
+
+    private static Dictionary<string, string> ParseChallengeParameters(string? value)
+    {
+        var parameters = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return parameters;
+        }
+
+        var index = 0;
+        while (index < value.Length)
+        {
+            while (index < value.Length && (value[index] == ',' || char.IsWhiteSpace(value[index])))
+            {
+                index++;
+            }
+
+            var keyStart = index;
+            while (index < value.Length && value[index] != '=' && value[index] != ',')
+            {
+                index++;
+            }
+
+            if (index >= value.Length || value[index] != '=')
+            {
+                break;
+            }
+
+            var key = value[keyStart..index].Trim();
+            index++;
+
+            var parameterValue = ReadChallengeValue(value, ref index);
+            if (!string.IsNullOrWhiteSpace(key))
+            {
+                parameters[key] = parameterValue;
+            }
+        }
+
+        return parameters;
+    }
+
+    private static string ReadChallengeValue(string value, ref int index)
+    {
+        if (index >= value.Length || value[index] != '"')
+        {
+            var start = index;
+            while (index < value.Length && value[index] != ',')
+            {
+                index++;
+            }
+
+            return value[start..index].Trim();
+        }
+
+        index++;
+        var result = new StringBuilder();
+        while (index < value.Length)
+        {
+            var current = value[index++];
+            if (current == '"')
+            {
+                break;
+            }
+
+            if (current == '\\' && index < value.Length)
+            {
+                current = value[index++];
+            }
+
+            result.Append(current);
+        }
+
+        return result.ToString();
+    }
+
+    private readonly record struct OciBearerChallenge(string Realm, string? Service, string? Scope);
 }

--- a/src/AvantiPoint.Packages.Registry.Oci/OciRegistryEndpoints.cs
+++ b/src/AvantiPoint.Packages.Registry.Oci/OciRegistryEndpoints.cs
@@ -16,6 +16,8 @@ public static class OciRegistryEndpoints
 
     public static IServiceCollection AddOciRegistry(this IServiceCollection services)
     {
+        services.AddHttpClient(nameof(OciMirrorService));
+        services.AddScoped<IOciMirrorService, OciMirrorService>();
         services.AddScoped<IOciRegistryService, OciRegistryService>();
         services.AddSingleton<OciFeedOptionsAccessor>();
         services.AddScoped<OciGarbageCollectionService>();
@@ -249,7 +251,7 @@ public static class OciRegistryEndpoints
             return Results.StatusCode(StatusCodes.Status200OK);
         }
 
-        var blob = await service.GetBlobAsync(surface, route.Digest!, cancellationToken);
+        var blob = await service.GetBlobAsync(surface, route.Digest!, route.RepositoryName, cancellationToken);
         if (blob is null)
         {
             return Results.NotFound();

--- a/src/AvantiPoint.Packages.Registry.Oci/OciRegistryEndpoints.cs
+++ b/src/AvantiPoint.Packages.Registry.Oci/OciRegistryEndpoints.cs
@@ -240,7 +240,7 @@ public static class OciRegistryEndpoints
     {
         if (httpContext.Request.Method == HttpMethods.Head)
         {
-            var exists = await service.BlobExistsAsync(surface, route.Digest!, cancellationToken);
+            var exists = await service.BlobExistsAsync(surface, route.Digest!, route.RepositoryName, cancellationToken);
             if (!exists.Exists)
             {
                 return Results.NotFound();

--- a/src/AvantiPoint.Packages.Registry.Oci/OciRegistryService.cs
+++ b/src/AvantiPoint.Packages.Registry.Oci/OciRegistryService.cs
@@ -467,10 +467,12 @@ public sealed class OciRegistryService : IOciRegistryService
                 cancellationToken);
 
             var mirroredTag = await _context.OciTags
+                .Include(t => t.Repository)
                 .FirstOrDefaultAsync(
                     t => t.FeedId == scope.FeedId
                          && t.OciSegment == scope.OciSegment
-                         && t.Tag == reference,
+                         && t.Tag == reference
+                         && t.Repository.Name == repositoryName,
                     cancellationToken);
 
             if (mirroredTag is not null)

--- a/src/AvantiPoint.Packages.Registry.Oci/OciRegistryService.cs
+++ b/src/AvantiPoint.Packages.Registry.Oci/OciRegistryService.cs
@@ -46,7 +46,7 @@ public sealed class OciRegistryService : IOciRegistryService
         var digest = await ResolveManifestDigestAsync(scope, repositoryName, reference, cancellationToken);
         if (digest is null)
         {
-            return null;
+            return await TryFetchUpstreamManifestAsync(surface, scope, repositoryName, reference, cancellationToken);
         }
 
         var manifest = await _context.OciManifests
@@ -59,51 +59,7 @@ public sealed class OciRegistryService : IOciRegistryService
 
         if (manifest is null)
         {
-            var upstream = await _mirror.TryFetchManifestAsync(surface, repositoryName, reference, cancellationToken);
-            if (upstream is null)
-            {
-                return null;
-            }
-
-            if (_mirror.ShouldPersist(surface))
-            {
-                await using var content = new MemoryStream(upstream.Content);
-                await PutManifestAsync(
-                    surface,
-                    repositoryName,
-                    reference,
-                    upstream.MediaType,
-                    content,
-                    cancellationToken);
-
-                var mirroredTag = await _context.OciTags
-                    .FirstOrDefaultAsync(
-                        t => t.FeedId == scope.FeedId
-                             && t.OciSegment == scope.OciSegment
-                             && t.Tag == reference,
-                        cancellationToken);
-
-                if (mirroredTag is not null)
-                {
-                    mirroredTag.Origin = _mirror.MirrorOrigin(surface);
-                    var mirroredManifest = await _context.OciManifests.FirstOrDefaultAsync(
-                        m => m.FeedId == scope.FeedId
-                             && m.OciSegment == scope.OciSegment
-                             && m.Digest == upstream.Digest,
-                        cancellationToken);
-                    if (mirroredManifest is not null)
-                    {
-                        mirroredManifest.Origin = _mirror.MirrorOrigin(surface);
-                    }
-
-                    await _context.SaveChangesAsync(cancellationToken);
-                }
-
-                return await GetManifestAsync(surface, repositoryName, reference, cancellationToken);
-            }
-
-            _metrics.RecordPull(surface, repositoryName);
-            return new OciManifestResult(upstream.Digest, upstream.MediaType, upstream.Content);
+            return await TryFetchUpstreamManifestAsync(surface, scope, repositoryName, reference, cancellationToken);
         }
 
         var store = GetDigestStore(surface);
@@ -240,6 +196,7 @@ public sealed class OciRegistryService : IOciRegistryService
     public async Task<OciBlobExistsResult> BlobExistsAsync(
         SurfaceContext surface,
         string digest,
+        string? repositoryName = null,
         CancellationToken cancellationToken = default)
     {
         var scope = ToScope(surface);
@@ -251,9 +208,25 @@ public sealed class OciRegistryService : IOciRegistryService
                      && b.Digest == digest,
                 cancellationToken);
 
-        return blob is null
-            ? new OciBlobExistsResult(false, 0)
-            : new OciBlobExistsResult(true, blob.Size);
+        if (blob is not null)
+        {
+            return new OciBlobExistsResult(true, blob.Size);
+        }
+
+        var store = GetDigestStore(surface);
+        var (algorithm, hex) = DigestBlobStore.ParseDigest(digest);
+        if (await store.ExistsAsync(algorithm, hex, cancellationToken))
+        {
+            return new OciBlobExistsResult(true, 0);
+        }
+
+        if (string.IsNullOrEmpty(repositoryName))
+        {
+            return new OciBlobExistsResult(false, 0);
+        }
+
+        var upstream = await _mirror.TryCheckBlobExistsAsync(surface, repositoryName, digest, cancellationToken);
+        return upstream ?? new OciBlobExistsResult(false, 0);
     }
 
     public async Task<OciStartUploadResult> StartUploadAsync(
@@ -467,6 +440,60 @@ public sealed class OciRegistryService : IOciRegistryService
         }
 
         return new OciCatalogResult(names.ToList());
+    }
+
+    private async Task<OciManifestResult?> TryFetchUpstreamManifestAsync(
+        SurfaceContext surface,
+        OciScope scope,
+        string repositoryName,
+        string reference,
+        CancellationToken cancellationToken)
+    {
+        var upstream = await _mirror.TryFetchManifestAsync(surface, repositoryName, reference, cancellationToken);
+        if (upstream is null)
+        {
+            return null;
+        }
+
+        if (_mirror.ShouldPersist(surface))
+        {
+            await using var content = new MemoryStream(upstream.Content);
+            await PutManifestAsync(
+                surface,
+                repositoryName,
+                reference,
+                upstream.MediaType,
+                content,
+                cancellationToken);
+
+            var mirroredTag = await _context.OciTags
+                .FirstOrDefaultAsync(
+                    t => t.FeedId == scope.FeedId
+                         && t.OciSegment == scope.OciSegment
+                         && t.Tag == reference,
+                    cancellationToken);
+
+            if (mirroredTag is not null)
+            {
+                mirroredTag.Origin = _mirror.MirrorOrigin(surface);
+                var mirroredManifest = await _context.OciManifests.FirstOrDefaultAsync(
+                    m => m.FeedId == scope.FeedId
+                         && m.OciSegment == scope.OciSegment
+                         && m.Digest == upstream.Digest,
+                    cancellationToken);
+                if (mirroredManifest is not null)
+                {
+                    mirroredManifest.Origin = _mirror.MirrorOrigin(surface);
+                }
+
+                await _context.SaveChangesAsync(cancellationToken);
+            }
+
+            return await GetManifestAsync(surface, repositoryName, reference, cancellationToken);
+        }
+
+        _metrics.RecordPull(surface, repositoryName);
+        return new OciManifestResult(upstream.Digest, upstream.MediaType, upstream.Content);
     }
 
     private async Task<string?> ResolveManifestDigestAsync(

--- a/src/AvantiPoint.Packages.Registry.Oci/OciRegistryService.cs
+++ b/src/AvantiPoint.Packages.Registry.Oci/OciRegistryService.cs
@@ -172,6 +172,18 @@ public sealed class OciRegistryService : IOciRegistryService
             await using (upstreamStream)
             {
                 upstreamStream.Position = 0;
+                var actualDigest = await DigestBlobStore.ComputeSha256DigestAsync(upstreamStream, cancellationToken);
+                if (!string.Equals(actualDigest, digest, StringComparison.OrdinalIgnoreCase))
+                {
+                    _logger.LogWarning(
+                        "Rejected mirrored OCI blob {Digest} from {RepositoryName}; upstream bytes hashed to {ActualDigest}",
+                        digest,
+                        repositoryName,
+                        actualDigest);
+                    return null;
+                }
+
+                upstreamStream.Position = 0;
                 await store.PutAsync(algorithm, hex, upstreamStream, cancellationToken);
                 await EnsureBlobRecordAsync(scope, digest, upstreamStream.Length, cancellationToken);
             }

--- a/src/AvantiPoint.Packages.Registry.Oci/OciRegistryService.cs
+++ b/src/AvantiPoint.Packages.Registry.Oci/OciRegistryService.cs
@@ -17,6 +17,7 @@ public sealed class OciRegistryService : IOciRegistryService
     private readonly IStorageBackendFactory _storageFactory;
     private readonly OciFeedOptionsAccessor _optionsAccessor;
     private readonly FeedMetricsService _metrics;
+    private readonly IOciMirrorService _mirror;
     private readonly ILogger<OciRegistryService> _logger;
 
     public OciRegistryService(
@@ -24,12 +25,14 @@ public sealed class OciRegistryService : IOciRegistryService
         IStorageBackendFactory storageFactory,
         OciFeedOptionsAccessor optionsAccessor,
         FeedMetricsService metrics,
+        IOciMirrorService mirror,
         ILogger<OciRegistryService> logger)
     {
         _context = context;
         _storageFactory = storageFactory;
         _optionsAccessor = optionsAccessor;
         _metrics = metrics;
+        _mirror = mirror;
         _logger = logger;
     }
 
@@ -56,7 +59,51 @@ public sealed class OciRegistryService : IOciRegistryService
 
         if (manifest is null)
         {
-            return null;
+            var upstream = await _mirror.TryFetchManifestAsync(surface, repositoryName, reference, cancellationToken);
+            if (upstream is null)
+            {
+                return null;
+            }
+
+            if (_mirror.ShouldPersist(surface))
+            {
+                await using var content = new MemoryStream(upstream.Content);
+                await PutManifestAsync(
+                    surface,
+                    repositoryName,
+                    reference,
+                    upstream.MediaType,
+                    content,
+                    cancellationToken);
+
+                var mirroredTag = await _context.OciTags
+                    .FirstOrDefaultAsync(
+                        t => t.FeedId == scope.FeedId
+                             && t.OciSegment == scope.OciSegment
+                             && t.Tag == reference,
+                        cancellationToken);
+
+                if (mirroredTag is not null)
+                {
+                    mirroredTag.Origin = _mirror.MirrorOrigin(surface);
+                    var mirroredManifest = await _context.OciManifests.FirstOrDefaultAsync(
+                        m => m.FeedId == scope.FeedId
+                             && m.OciSegment == scope.OciSegment
+                             && m.Digest == upstream.Digest,
+                        cancellationToken);
+                    if (mirroredManifest is not null)
+                    {
+                        mirroredManifest.Origin = _mirror.MirrorOrigin(surface);
+                    }
+
+                    await _context.SaveChangesAsync(cancellationToken);
+                }
+
+                return await GetManifestAsync(surface, repositoryName, reference, cancellationToken);
+            }
+
+            _metrics.RecordPull(surface, repositoryName);
+            return new OciManifestResult(upstream.Digest, upstream.MediaType, upstream.Content);
         }
 
         var store = GetDigestStore(surface);
@@ -131,6 +178,7 @@ public sealed class OciRegistryService : IOciRegistryService
     public async Task<OciBlobResult?> GetBlobAsync(
         SurfaceContext surface,
         string digest,
+        string? repositoryName = null,
         CancellationToken cancellationToken = default)
     {
         var scope = ToScope(surface);
@@ -142,16 +190,51 @@ public sealed class OciRegistryService : IOciRegistryService
                      && b.Digest == digest,
                 cancellationToken);
 
-        if (blob is null)
+        var store = GetDigestStore(surface);
+        var (algorithm, hex) = DigestBlobStore.ParseDigest(digest);
+        var stream = await store.GetAsync(algorithm, hex, cancellationToken);
+        if (stream is not null)
+        {
+            var size = blob?.Size ?? stream.Length;
+            _metrics.RecordPull(surface, digest);
+            return new OciBlobResult(digest, stream, size);
+        }
+
+        if (string.IsNullOrEmpty(repositoryName))
         {
             return null;
         }
 
-        var store = GetDigestStore(surface);
-        var (algorithm, hex) = DigestBlobStore.ParseDigest(digest);
-        var stream = await store.GetAsync(algorithm, hex, cancellationToken);
+        var upstreamStream = await _mirror.TryFetchBlobAsync(surface, repositoryName, digest, cancellationToken);
+        if (upstreamStream is null)
+        {
+            return null;
+        }
+
+        if (_mirror.ShouldPersist(surface))
+        {
+            await using (upstreamStream)
+            {
+                upstreamStream.Position = 0;
+                await store.PutAsync(algorithm, hex, upstreamStream, cancellationToken);
+                await EnsureBlobRecordAsync(scope, digest, upstreamStream.Length, cancellationToken);
+            }
+
+            stream = await store.GetAsync(algorithm, hex, cancellationToken);
+            if (stream is null)
+            {
+                return null;
+            }
+
+            var persisted = await _context.OciBlobs.AsNoTracking().FirstOrDefaultAsync(
+                b => b.FeedId == scope.FeedId && b.OciSegment == scope.OciSegment && b.Digest == digest,
+                cancellationToken);
+            _metrics.RecordPull(surface, digest);
+            return new OciBlobResult(digest, stream, persisted?.Size ?? stream.Length);
+        }
+
         _metrics.RecordPull(surface, digest);
-        return new OciBlobResult(digest, stream, blob.Size);
+        return new OciBlobResult(digest, upstreamStream, upstreamStream.Length);
     }
 
     public async Task<OciBlobExistsResult> BlobExistsAsync(
@@ -363,16 +446,12 @@ public sealed class OciRegistryService : IOciRegistryService
 
         var repositories = await _context.OciRepositories
             .AsNoTracking()
+            .Include(r => r.Tags)
             .Where(r => r.FeedId == scope.FeedId && r.OciSegment == scope.OciSegment)
-            .Select(r => new
-            {
-                r.Name,
-                HasVisibleTag = r.Tags.Any(t => IsVisibleInDiscovery(t.Origin, options)),
-            })
             .ToListAsync(cancellationToken);
 
         var names = repositories
-            .Where(r => r.HasVisibleTag)
+            .Where(r => r.Tags.Any(t => IsVisibleInDiscovery(t.Origin, options)))
             .Select(r => r.Name)
             .OrderBy(n => n, StringComparer.Ordinal)
             .AsEnumerable();

--- a/src/AvantiPoint.Packages.Registry.Oci/OciRegistryService.cs
+++ b/src/AvantiPoint.Packages.Registry.Oci/OciRegistryService.cs
@@ -148,9 +148,9 @@ public sealed class OciRegistryService : IOciRegistryService
 
         var store = GetDigestStore(surface);
         var (algorithm, hex) = DigestBlobStore.ParseDigest(digest);
-        var stream = await store.GetAsync(algorithm, hex, cancellationToken);
-        if (stream is not null)
+        if (await store.ExistsAsync(algorithm, hex, cancellationToken))
         {
+            var stream = await store.GetAsync(algorithm, hex, cancellationToken);
             var size = blob?.Size ?? stream.Length;
             _metrics.RecordPull(surface, digest);
             return new OciBlobResult(digest, stream, size);
@@ -176,11 +176,12 @@ public sealed class OciRegistryService : IOciRegistryService
                 await EnsureBlobRecordAsync(scope, digest, upstreamStream.Length, cancellationToken);
             }
 
-            stream = await store.GetAsync(algorithm, hex, cancellationToken);
-            if (stream is null)
+            if (!await store.ExistsAsync(algorithm, hex, cancellationToken))
             {
                 return null;
             }
+
+            var stream = await store.GetAsync(algorithm, hex, cancellationToken);
 
             var persisted = await _context.OciBlobs.AsNoTracking().FirstOrDefaultAsync(
                 b => b.FeedId == scope.FeedId && b.OciSegment == scope.OciSegment && b.Digest == digest,

--- a/src/AvantiPoint.Packages.Registry.Oci/OciRegistryService.cs
+++ b/src/AvantiPoint.Packages.Registry.Oci/OciRegistryService.cs
@@ -115,10 +115,10 @@ public sealed class OciRegistryService : IOciRegistryService
             }
         }
 
-        await EnsureManifestRecordAsync(scope, digest, mediaType, parsed, bytes.Length, cancellationToken);
+        await EnsureManifestRecordAsync(scope, digest, mediaType, parsed, bytes.Length, PackageOrigin.Published, cancellationToken);
         await EnsureRepositoryAsync(scope, repositoryName, cancellationToken);
 
-        await UpsertTagAsync(scope, repositoryName, reference, digest, cancellationToken);
+        await UpsertTagAsync(scope, repositoryName, reference, digest, PackageOrigin.Published, cancellationToken);
 
         _metrics.RecordPush(surface, repositoryName);
         _logger.LogInformation(
@@ -457,45 +457,67 @@ public sealed class OciRegistryService : IOciRegistryService
 
         if (_mirror.ShouldPersist(surface))
         {
-            await using var content = new MemoryStream(upstream.Content);
-            await PutManifestAsync(
+            await PersistMirroredManifestAsync(
                 surface,
+                scope,
                 repositoryName,
                 reference,
-                upstream.MediaType,
-                content,
+                upstream,
                 cancellationToken);
-
-            var mirroredTag = await _context.OciTags
-                .Include(t => t.Repository)
-                .FirstOrDefaultAsync(
-                    t => t.FeedId == scope.FeedId
-                         && t.OciSegment == scope.OciSegment
-                         && t.Tag == reference
-                         && t.Repository.Name == repositoryName,
-                    cancellationToken);
-
-            if (mirroredTag is not null)
-            {
-                mirroredTag.Origin = _mirror.MirrorOrigin(surface);
-                var mirroredManifest = await _context.OciManifests.FirstOrDefaultAsync(
-                    m => m.FeedId == scope.FeedId
-                         && m.OciSegment == scope.OciSegment
-                         && m.Digest == upstream.Digest,
-                    cancellationToken);
-                if (mirroredManifest is not null)
-                {
-                    mirroredManifest.Origin = _mirror.MirrorOrigin(surface);
-                }
-
-                await _context.SaveChangesAsync(cancellationToken);
-            }
 
             return await GetManifestAsync(surface, repositoryName, reference, cancellationToken);
         }
 
         _metrics.RecordPull(surface, repositoryName);
         return new OciManifestResult(upstream.Digest, upstream.MediaType, upstream.Content);
+    }
+
+    private async Task PersistMirroredManifestAsync(
+        SurfaceContext surface,
+        OciScope scope,
+        string repositoryName,
+        string reference,
+        OciUpstreamManifest upstream,
+        CancellationToken cancellationToken)
+    {
+        var options = _optionsAccessor.GetOptions(surface);
+        if (!OciManifestParser.IsAllowedMediaType(upstream.MediaType, options.AllowUnknownMediaTypes))
+        {
+            throw new OciRegistryException("Manifest media type is not allowed.");
+        }
+
+        var parsed = OciManifestParser.Parse(upstream.MediaType, upstream.Content);
+        ValidatePlatformPolicy(options, parsed);
+
+        using var buffer = new MemoryStream(upstream.Content);
+        var digest = await DigestBlobStore.ComputeSha256DigestAsync(buffer, cancellationToken);
+        if (!string.Equals(digest, upstream.Digest, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new OciRegistryException(
+                $"Upstream manifest digest does not match content. Expected '{upstream.Digest}', computed '{digest}'.");
+        }
+
+        var store = GetDigestStore(surface);
+        var (algorithm, hex) = DigestBlobStore.ParseDigest(digest);
+        buffer.Position = 0;
+        if (!await store.ExistsAsync(algorithm, hex, cancellationToken))
+        {
+            await store.PutAsync(algorithm, hex, buffer, cancellationToken);
+            await EnsureBlobRecordAsync(scope, digest, upstream.Content.Length, cancellationToken);
+        }
+
+        var origin = _mirror.MirrorOrigin(surface);
+        await EnsureManifestRecordAsync(scope, digest, upstream.MediaType, parsed, upstream.Content.Length, origin, cancellationToken);
+        await EnsureRepositoryAsync(scope, repositoryName, cancellationToken);
+        await UpsertTagAsync(scope, repositoryName, reference, digest, origin, cancellationToken);
+
+        _metrics.RecordPull(surface, repositoryName);
+        _logger.LogInformation(
+            "Mirrored OCI manifest {Digest} to {Repository} on feed {FeedId} segment {Segment}",
+            digest,
+            repositoryName,
+            scope.FeedId,
+            scope.OciSegment ?? "(default)");
     }
 
     private async Task<string?> ResolveManifestDigestAsync(
@@ -588,16 +610,19 @@ public sealed class OciRegistryService : IOciRegistryService
         string mediaType,
         ParsedOciManifest parsed,
         long size,
+        PackageOrigin origin,
         CancellationToken cancellationToken)
     {
-        var exists = await _context.OciManifests.AnyAsync(
+        var existing = await _context.OciManifests.FirstOrDefaultAsync(
             m => m.FeedId == scope.FeedId
                  && m.OciSegment == scope.OciSegment
                  && m.Digest == digest,
             cancellationToken);
 
-        if (exists)
+        if (existing is not null)
         {
+            existing.Origin = origin;
+            await _context.SaveChangesAsync(cancellationToken);
             return;
         }
 
@@ -610,7 +635,7 @@ public sealed class OciRegistryService : IOciRegistryService
             PlatformOs = parsed.PlatformOs,
             PlatformArch = parsed.PlatformArch,
             ArtifactKind = parsed.ArtifactKind,
-            Origin = PackageOrigin.Published,
+            Origin = origin,
             Size = size,
         });
         await _context.SaveChangesAsync(cancellationToken);
@@ -649,6 +674,7 @@ public sealed class OciRegistryService : IOciRegistryService
         string repositoryName,
         string tag,
         string digest,
+        PackageOrigin origin,
         CancellationToken cancellationToken)
     {
         var repository = await _context.OciRepositories
@@ -669,12 +695,13 @@ public sealed class OciRegistryService : IOciRegistryService
                 RepositoryKey = repository.Key,
                 Tag = tag,
                 ManifestDigest = digest,
-                Origin = PackageOrigin.Published,
+                Origin = origin,
             });
         }
         else
         {
             existing.ManifestDigest = digest;
+            existing.Origin = origin;
         }
 
         await _context.SaveChangesAsync(cancellationToken);

--- a/src/AvantiPoint.Packages.Registry.Oci/OciUpstreamManifest.cs
+++ b/src/AvantiPoint.Packages.Registry.Oci/OciUpstreamManifest.cs
@@ -1,0 +1,3 @@
+namespace AvantiPoint.Packages.Registry.Oci;
+
+public sealed record OciUpstreamManifest(string Digest, string MediaType, byte[] Content);

--- a/src/AvantiPoint.Packages.UI.Razor/Services/NpmPackageBrowseService.cs
+++ b/src/AvantiPoint.Packages.UI.Razor/Services/NpmPackageBrowseService.cs
@@ -1,6 +1,9 @@
 using AvantiPoint.Feed.Platform;
+using AvantiPoint.Feed.Platform.Configuration;
+using AvantiPoint.Feed.Platform.Mirror;
 using AvantiPoint.Packages.Core;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 
 namespace AvantiPoint.Packages.UI.Services;
 
@@ -8,11 +11,19 @@ public sealed class NpmPackageBrowseService : INpmPackageBrowseService
 {
     private readonly IContext _context;
     private readonly IFeedRegistry _feedRegistry;
+    private readonly IMirrorPolicyService _policy;
+    private readonly NpmFeedOptions _npmOptions;
 
-    public NpmPackageBrowseService(IContext context, IFeedRegistry feedRegistry)
+    public NpmPackageBrowseService(
+        IContext context,
+        IFeedRegistry feedRegistry,
+        IMirrorPolicyService policy,
+        IOptions<NpmFeedOptions> npmOptions)
     {
         _context = context;
         _feedRegistry = feedRegistry;
+        _policy = policy;
+        _npmOptions = npmOptions.Value;
     }
 
     public async Task<IReadOnlyList<NpmPackageListItem>> SearchAsync(
@@ -31,25 +42,23 @@ public sealed class NpmPackageBrowseService : INpmPackageBrowseService
         }
 
         var rows = await packages
-            .OrderBy(p => p.Name)
-            .Skip(skip)
-            .Take(take)
             .Select(p => new
             {
                 p.Name,
-                LatestVersion = p.Versions
+                Latest = p.Versions
                     .OrderByDescending(v => v.Published)
-                    .Select(v => v.Version)
-                    .FirstOrDefault(),
-                Published = p.Versions
-                    .OrderByDescending(v => v.Published)
-                    .Select(v => (DateTime?)v.Published)
+                    .Select(v => new { v.Version, v.Published, v.Origin })
                     .FirstOrDefault(),
             })
             .ToListAsync(cancellationToken);
 
         return rows
-            .Select(r => new NpmPackageListItem(r.Name, r.LatestVersion, r.Published))
+            .Where(r => r.Latest != null
+                        && _policy.IncludeInDiscovery(FeedProtocol.Npm, r.Latest.Origin))
+            .OrderBy(r => r.Name)
+            .Skip(skip)
+            .Take(take)
+            .Select(r => new NpmPackageListItem(r.Name, r.Latest!.Version, r.Latest.Published))
             .ToList();
     }
 

--- a/src/AvantiPoint.Packages.UI.Razor/Services/NpmPackageBrowseService.cs
+++ b/src/AvantiPoint.Packages.UI.Razor/Services/NpmPackageBrowseService.cs
@@ -2,6 +2,7 @@ using AvantiPoint.Feed.Platform;
 using AvantiPoint.Feed.Platform.Configuration;
 using AvantiPoint.Feed.Platform.Mirror;
 using AvantiPoint.Packages.Core;
+using AvantiPoint.Packages.Core.Entities.Npm;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 
@@ -42,19 +43,13 @@ public sealed class NpmPackageBrowseService : INpmPackageBrowseService
         }
 
         var rows = await packages
-            .Select(p => new
-            {
-                p.Name,
-                Latest = p.Versions
-                    .OrderByDescending(v => v.Published)
-                    .Select(v => new { v.Version, v.Published, v.Origin })
-                    .FirstOrDefault(),
-            })
+            .Include(p => p.Versions)
+            .AsSplitQuery()
             .ToListAsync(cancellationToken);
 
         return rows
-            .Where(r => r.Latest != null
-                        && _policy.IncludeInDiscovery(FeedProtocol.Npm, r.Latest.Origin))
+            .Select(r => new { r.Name, Latest = SelectLatestVisibleVersion(r.Versions) })
+            .Where(r => r.Latest != null)
             .OrderBy(r => r.Name)
             .Skip(skip)
             .Take(take)
@@ -96,4 +91,10 @@ public sealed class NpmPackageBrowseService : INpmPackageBrowseService
         packageName.StartsWith('@')
             ? packageName
             : packageName.ToLowerInvariant();
+
+    private NpmVersion? SelectLatestVisibleVersion(IEnumerable<NpmVersion> versions) =>
+        versions
+            .Where(v => _policy.IncludeInDiscovery(FeedProtocol.Npm, v.Origin))
+            .OrderByDescending(v => v.Published)
+            .FirstOrDefault();
 }

--- a/tests/AvantiPoint.Packages.Integration.Tests/AvantiPoint.Packages.Integration.Tests.csproj
+++ b/tests/AvantiPoint.Packages.Integration.Tests/AvantiPoint.Packages.Integration.Tests.csproj
@@ -36,6 +36,7 @@
     <ProjectReference Include="..\..\samples\OpenFeed\OpenFeed.csproj" />
     <ProjectReference Include="..\..\src\AvantiPoint.Packages.Protocol\AvantiPoint.Packages.Protocol.csproj" />
     <ProjectReference Include="..\..\src\AvantiPoint.Feed.Platform\AvantiPoint.Feed.Platform.csproj" />
+    <ProjectReference Include="..\AvantiPoint.Packages.Registry.Tests.Shared\AvantiPoint.Packages.Registry.Tests.Shared.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/AvantiPoint.Packages.Integration.Tests/CrossFeedIsolationIntegrationTests.cs
+++ b/tests/AvantiPoint.Packages.Integration.Tests/CrossFeedIsolationIntegrationTests.cs
@@ -49,6 +49,23 @@ public sealed class CrossFeedIsolationIntegrationTests
 
         await TestPackageBuilder.PublishAsync(feed.Client, "Local.Feed.Package", "1.0.0");
 
+        using (var scope = feed.Services.CreateScope())
+        {
+            var context = scope.ServiceProvider.GetRequiredService<IContext>();
+            context.Packages.Add(new Package
+            {
+                FeedId = "other-feed",
+                Id = "Local.Feed.Package",
+                Version = NuGet.Versioning.NuGetVersion.Parse("9.0.0"),
+                NormalizedVersionString = "9.0.0",
+                OriginalVersionString = "9.0.0",
+                Listed = true,
+                Published = DateTime.UtcNow.AddDays(1),
+                Origin = PackageOrigin.Published,
+            });
+            await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
         var search = await feed.Client.GetAsync(
             "/v3/search?q=Package&take=20&prerelease=true",
             TestContext.Current.CancellationToken);
@@ -62,6 +79,24 @@ public sealed class CrossFeedIsolationIntegrationTests
 
         Assert.Contains("Local.Feed.Package", ids);
         Assert.DoesNotContain("Other.Feed.Package", ids);
+
+        var localPackage = json.RootElement.GetProperty("data")
+            .EnumerateArray()
+            .Single(e => e.GetProperty("id").GetString() == "Local.Feed.Package");
+        Assert.Equal("1.0.0", localPackage.GetProperty("version").GetString());
+        var versions = localPackage.GetProperty("versions")
+            .EnumerateArray()
+            .Select(e => e.GetProperty("version").GetString())
+            .ToList();
+        Assert.DoesNotContain("9.0.0", versions);
+
+        using var packageScope = feed.Services.CreateScope();
+        var packages = await packageScope.ServiceProvider
+            .GetRequiredService<IPackageService>()
+            .FindAsync("Local.Feed.Package", includeUnlisted: false, TestContext.Current.CancellationToken);
+        var packageVersions = packages.Select(p => p.Version.ToNormalizedString()).ToList();
+        Assert.Contains("1.0.0", packageVersions);
+        Assert.DoesNotContain("9.0.0", packageVersions);
     }
 
     [Fact]

--- a/tests/AvantiPoint.Packages.Integration.Tests/CrossFeedIsolationIntegrationTests.cs
+++ b/tests/AvantiPoint.Packages.Integration.Tests/CrossFeedIsolationIntegrationTests.cs
@@ -1,0 +1,93 @@
+using System.Net;
+using System.Text.Json;
+using AvantiPoint.Feed.Platform;
+using AvantiPoint.Feed.Platform.Routing;
+using AvantiPoint.Packages.Core;
+using AvantiPoint.Packages.Integration.Tests.TestInfrastructure;
+using AvantiPoint.Packages.Registry.Tests.Shared;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace AvantiPoint.Packages.Integration.Tests;
+
+public sealed class CrossFeedIsolationIntegrationTests
+{
+    [Theory]
+    [InlineData("/v3/index.json", FeedProtocol.NuGet)]
+    [InlineData("/api/v3/search", FeedProtocol.NuGet)]
+    [InlineData("/npm/-/v1/search", FeedProtocol.Npm)]
+    public void FeedSurfaceMatcher_RoutesProtocolsCorrectly(string path, FeedProtocol protocol)
+    {
+        var registry = CreateMultiSurfaceRegistry();
+        var match = FeedSurfaceMatcher.Match(registry, new PathString(path));
+        Assert.NotNull(match);
+        Assert.Equal(protocol, match.Registration.Protocol);
+    }
+
+    [Fact]
+    public async Task NuGetSearch_ExcludesPackagesFromOtherFeedId()
+    {
+        await using var feed = await FeedUnderTestHost.StartAsync(new FeedUnderTestOptions());
+
+        using (var scope = feed.Services.CreateScope())
+        {
+            var context = scope.ServiceProvider.GetRequiredService<IContext>();
+            context.Packages.Add(new Package
+            {
+                FeedId = "other-feed",
+                Id = "Other.Feed.Package",
+                Version = NuGet.Versioning.NuGetVersion.Parse("1.0.0"),
+                NormalizedVersionString = "1.0.0",
+                OriginalVersionString = "1.0.0",
+                Listed = true,
+                Published = DateTime.UtcNow,
+                Origin = PackageOrigin.Published,
+            });
+            await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await TestPackageBuilder.PublishAsync(feed.Client, "Local.Feed.Package", "1.0.0");
+
+        var search = await feed.Client.GetAsync(
+            "/v3/search?q=Package&take=20&prerelease=true",
+            TestContext.Current.CancellationToken);
+        search.EnsureSuccessStatusCode();
+
+        var json = JsonDocument.Parse(await search.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
+        var ids = json.RootElement.GetProperty("data")
+            .EnumerateArray()
+            .Select(e => e.GetProperty("id").GetString())
+            .ToList();
+
+        Assert.Contains("Local.Feed.Package", ids);
+        Assert.DoesNotContain("Other.Feed.Package", ids);
+    }
+
+    [Fact]
+    public async Task OciNamedSegment_UsesSeparateRegistryRoots()
+    {
+        await using var host = await FeedTestServerHost.StartAsync();
+        var client = host.Client;
+
+        var defaultRoot = await client.GetAsync("/v2/");
+        var dockerRoot = await client.GetAsync("/docker/v2/");
+        var helmEmbedded = await client.GetAsync("/v2/helm/");
+
+        Assert.Equal(HttpStatusCode.OK, defaultRoot.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, dockerRoot.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, helmEmbedded.StatusCode);
+    }
+
+    private static IFeedRegistry CreateMultiSurfaceRegistry()
+    {
+        var feed = new FeedContext("default", "default", "feeds/default/");
+        var registry = new FeedRegistry(feed);
+        registry.Register(new SurfaceRegistration("nuget", FeedProtocol.NuGet, null, string.Empty, "Feed:NuGet"));
+        registry.Register(new SurfaceRegistration("npm", FeedProtocol.Npm, null, "/npm", "Feed:Npm"));
+        registry.Register(new SurfaceRegistration("oci", FeedProtocol.Oci, null, string.Empty, "Feed:Oci:Default"));
+        registry.Register(new SurfaceRegistration("docker", FeedProtocol.Oci, "docker", "/docker", "Feed:Oci:Docker"));
+        return registry;
+    }
+
+}

--- a/tests/AvantiPoint.Packages.Registry.Npm.Tests/ConfigurableMirrorPolicyServiceTests.cs
+++ b/tests/AvantiPoint.Packages.Registry.Npm.Tests/ConfigurableMirrorPolicyServiceTests.cs
@@ -1,0 +1,61 @@
+using AvantiPoint.Feed.Platform;
+using AvantiPoint.Feed.Platform.Configuration;
+using AvantiPoint.Feed.Platform.Mirror;
+using AvantiPoint.Packages.Core;
+using Microsoft.Extensions.Options;
+
+namespace AvantiPoint.Packages.Registry.Npm.Tests;
+
+public class ConfigurableMirrorPolicyServiceTests
+{
+    [Fact]
+    public void GetStrategy_UsesConfiguredNpmCachingStrategy()
+    {
+        var service = CreateService(
+            new NpmFeedOptions
+            {
+                Mirror = new NpmMirrorOptions
+                {
+                    CachingStrategy = MirrorCachingStrategy.ProxyOnly,
+                },
+            },
+            new OciFeedOptions());
+
+        var strategy = service.GetStrategy(FeedProtocol.Npm);
+
+        Assert.Equal(MirrorCachingStrategy.ProxyOnly, strategy);
+    }
+
+    [Fact]
+    public void GetStrategy_UsesConfiguredOciCachingStrategy()
+    {
+        var service = CreateService(
+            new NpmFeedOptions(),
+            new OciFeedOptions
+            {
+                Mirror = new OciMirrorOptions
+                {
+                    CachingStrategy = MirrorCachingStrategy.CacheOnly,
+                },
+            });
+
+        var strategy = service.GetStrategy(FeedProtocol.Oci);
+
+        Assert.Equal(MirrorCachingStrategy.CacheOnly, strategy);
+    }
+
+    private static ConfigurableMirrorPolicyService CreateService(NpmFeedOptions npmOptions, OciFeedOptions ociOptions) =>
+        new(
+            Options.Create(new SearchOptions()),
+            Options.Create(npmOptions),
+            new TestOptionsMonitor<OciFeedOptions>(ociOptions));
+
+    private sealed class TestOptionsMonitor<TOptions>(TOptions currentValue) : IOptionsMonitor<TOptions>
+    {
+        public TOptions CurrentValue => currentValue;
+
+        public TOptions Get(string? name) => currentValue;
+
+        public IDisposable? OnChange(Action<TOptions, string?> listener) => null;
+    }
+}

--- a/tests/AvantiPoint.Packages.Registry.Npm.Tests/ConfigurableMirrorPolicyServiceTests.cs
+++ b/tests/AvantiPoint.Packages.Registry.Npm.Tests/ConfigurableMirrorPolicyServiceTests.cs
@@ -2,6 +2,8 @@ using AvantiPoint.Feed.Platform;
 using AvantiPoint.Feed.Platform.Configuration;
 using AvantiPoint.Feed.Platform.Mirror;
 using AvantiPoint.Packages.Core;
+using AvantiPoint.Packages.Registry.Npm;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 
 namespace AvantiPoint.Packages.Registry.Npm.Tests;
@@ -44,6 +46,26 @@ public class ConfigurableMirrorPolicyServiceTests
         Assert.Equal(MirrorCachingStrategy.CacheOnly, strategy);
     }
 
+    [Fact]
+    public void NpmMirrorService_MapsCacheOnlyMirrorsToCachedOrigin()
+    {
+        var options = new NpmFeedOptions
+        {
+            Mirror = new NpmMirrorOptions
+            {
+                CachingStrategy = MirrorCachingStrategy.CacheOnly,
+            },
+        };
+        var service = new NpmMirrorService(
+            Options.Create(options),
+            CreateService(options, new OciFeedOptions()),
+            new SingleClientHttpClientFactory(new HttpClient()),
+            NullLogger<NpmMirrorService>.Instance);
+
+        Assert.Equal(MirrorCachingStrategy.CacheOnly, service.Strategy);
+        Assert.Equal(PackageOrigin.Cached, service.MirrorOrigin);
+    }
+
     private static ConfigurableMirrorPolicyService CreateService(NpmFeedOptions npmOptions, OciFeedOptions ociOptions) =>
         new(
             Options.Create(new SearchOptions()),
@@ -57,5 +79,10 @@ public class ConfigurableMirrorPolicyServiceTests
         public TOptions Get(string? name) => currentValue;
 
         public IDisposable? OnChange(Action<TOptions, string?> listener) => null;
+    }
+
+    private sealed class SingleClientHttpClientFactory(HttpClient client) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => client;
     }
 }

--- a/tests/AvantiPoint.Packages.Registry.Npm.Tests/NpmRegistryTests.cs
+++ b/tests/AvantiPoint.Packages.Registry.Npm.Tests/NpmRegistryTests.cs
@@ -222,6 +222,32 @@ public class NpmRegistryTests : IClassFixture<NpmTestWebApplicationFactory>
     }
 
     [Fact]
+    public async Task ProxyOnlyMirror_RewritesTarballUrlsThroughFeed()
+    {
+        using var factory = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureTestServices(services =>
+            {
+                services.RemoveAll<INpmMirrorService>();
+                services.AddScoped<INpmMirrorService, ProxyOnlyNpmMirrorService>();
+            });
+        });
+
+        ProxyOnlyNpmMirrorService.PackageName = $"proxy-only-{Guid.NewGuid():N}";
+        ProxyOnlyNpmMirrorService.Version = "1.0.0";
+        var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", ApiKey);
+
+        var response = await client.GetAsync($"/npm/{ProxyOnlyNpmMirrorService.PackageName}", TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var packument = JsonNode.Parse(await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken))!.AsObject();
+        var tarballUrl = packument["versions"]![ProxyOnlyNpmMirrorService.Version]!["dist"]!["tarball"]!.GetValue<string>();
+        Assert.False(tarballUrl.StartsWith("https://example.test/", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains($"/npm/{ProxyOnlyNpmMirrorService.PackageName}/-/{ProxyOnlyNpmMirrorService.PackageName}-{ProxyOnlyNpmMirrorService.Version}.tgz", tarballUrl);
+    }
+
+    [Fact]
     public async Task MirroringScopedPackage_DoesNotMarkSameTarballNameFromAnotherPackageAsMirrored()
     {
         await EnsureDatabaseAsync();
@@ -319,6 +345,56 @@ public class NpmRegistryTests : IClassFixture<NpmTestWebApplicationFactory>
         }
 
         return root.ToJsonString();
+    }
+
+    private sealed class ProxyOnlyNpmMirrorService : INpmMirrorService
+    {
+        public static string PackageName { get; set; } = string.Empty;
+
+        public static string Version { get; set; } = string.Empty;
+
+        public MirrorCachingStrategy Strategy => MirrorCachingStrategy.ProxyOnly;
+
+        public PackageOrigin MirrorOrigin => PackageOrigin.Mirrored;
+
+        public Task<JsonObject?> FetchPackumentAsync(string packageName, CancellationToken cancellationToken = default)
+        {
+            var tarballFileName = GetTarballFileName(PackageName, Version);
+            JsonObject packument = new()
+            {
+                ["name"] = PackageName,
+                ["dist-tags"] = new JsonObject
+                {
+                    ["latest"] = Version,
+                },
+                ["versions"] = new JsonObject
+                {
+                    [Version] = new JsonObject
+                    {
+                        ["name"] = PackageName,
+                        ["version"] = Version,
+                        ["dist"] = new JsonObject
+                        {
+                            ["tarball"] = $"https://example.test/packages/{tarballFileName}",
+                        },
+                    },
+                },
+            };
+
+            return Task.FromResult<JsonObject?>(packument);
+        }
+
+        public Task<Stream?> FetchTarballAsync(string tarballUrl, CancellationToken cancellationToken = default) =>
+            Task.FromResult<Stream?>(new MemoryStream([0x1f, 0x8b, 0x08]));
+
+        private static string GetTarballFileName(string packageName, string version)
+        {
+            var shortName = packageName.Contains('@')
+                ? packageName[(packageName.IndexOf('/') + 1)..]
+                : packageName;
+
+            return $"{shortName}-{version}.tgz";
+        }
     }
 
     private sealed class FakeNpmMirrorService : INpmMirrorService

--- a/tests/AvantiPoint.Packages.Registry.Npm.Tests/NpmRegistryTests.cs
+++ b/tests/AvantiPoint.Packages.Registry.Npm.Tests/NpmRegistryTests.cs
@@ -4,6 +4,8 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using AvantiPoint.Feed.Platform.Callbacks;
+using AvantiPoint.Feed.Platform.Mirror;
+using AvantiPoint.Packages.Core;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
@@ -164,6 +166,68 @@ public class NpmRegistryTests : IClassFixture<NpmTestWebApplicationFactory>
     }
 
     [Fact]
+    public async Task Search_ClampsNegativePaginationParameters()
+    {
+        await EnsureDatabaseAsync();
+        var client = CreateAuthenticatedClient();
+        var packageName = $"negative-page-{Guid.NewGuid():N}";
+        var publishBody = BuildNpmPublishBody(packageName, "1.0.0", tarballBytes: [0x1f, 0x8b, 0x08]);
+
+        var publishResponse = await client.PutAsync(
+            $"/npm/{packageName}",
+            new StringContent(publishBody, Encoding.UTF8, "application/json"));
+        Assert.Equal(HttpStatusCode.Created, publishResponse.StatusCode);
+
+        var response = await client.GetAsync($"/npm/-/v1/search?text={packageName}&from=-10&size=-1");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var search = JsonNode.Parse(await response.Content.ReadAsStringAsync())!.AsObject();
+        Assert.Equal(1, search["total"]!.GetValue<int>());
+        Assert.Empty(search["objects"]!.AsArray());
+    }
+
+    [Fact]
+    public async Task MirroringScopedPackage_DoesNotMarkSameTarballNameFromAnotherPackageAsMirrored()
+    {
+        await EnsureDatabaseAsync();
+        var client = CreateAuthenticatedClient();
+        var shortName = $"collision-{Guid.NewGuid():N}";
+        var scopedName = $"@scope/{shortName}";
+        var encodedScopedName = scopedName.Replace("/", "%2f", StringComparison.Ordinal);
+        var version = "1.0.0";
+        FakeNpmMirrorService.PackageName = scopedName;
+        FakeNpmMirrorService.Version = version;
+
+        var publishBody = BuildNpmPublishBody(shortName, version, tarballBytes: [0x1f, 0x8b, 0x08]);
+        var publishResponse = await client.PutAsync(
+            $"/npm/{shortName}",
+            new StringContent(publishBody, Encoding.UTF8, "application/json"));
+        Assert.Equal(HttpStatusCode.Created, publishResponse.StatusCode);
+
+        using var factory = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureTestServices(services =>
+            {
+                services.RemoveAll<INpmMirrorService>();
+                services.AddScoped<INpmMirrorService, FakeNpmMirrorService>();
+            });
+        });
+
+        var mirrorClient = factory.CreateClient();
+        mirrorClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", ApiKey);
+        var mirrorResponse = await mirrorClient.GetAsync($"/npm/{encodedScopedName}");
+        Assert.Equal(HttpStatusCode.OK, mirrorResponse.StatusCode);
+
+        using var scope = factory.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<IContext>();
+        var published = context.NpmVersions.Single(v => v.Package.Name == shortName && v.Version == version);
+        var mirrored = context.NpmVersions.Single(v => v.Package.Name == scopedName && v.Version == version);
+
+        Assert.Equal(PackageOrigin.Published, published.Origin);
+        Assert.Equal(PackageOrigin.Mirrored, mirrored.Origin);
+    }
+
+    [Fact]
     public async Task UnregisteredOciSegment_ReturnsNotFound()
     {
         var client = _factory.CreateClient();
@@ -220,5 +284,55 @@ public class NpmRegistryTests : IClassFixture<NpmTestWebApplicationFactory>
         }
 
         return root.ToJsonString();
+    }
+
+    private sealed class FakeNpmMirrorService : INpmMirrorService
+    {
+        public static string PackageName { get; set; } = string.Empty;
+
+        public static string Version { get; set; } = string.Empty;
+
+        public MirrorCachingStrategy Strategy => MirrorCachingStrategy.IndexAndCache;
+
+        public PackageOrigin MirrorOrigin => PackageOrigin.Mirrored;
+
+        public Task<JsonObject?> FetchPackumentAsync(string packageName, CancellationToken cancellationToken = default)
+        {
+            var tarballFileName = GetTarballFileName(PackageName, Version);
+            JsonObject packument = new()
+            {
+                ["name"] = PackageName,
+                ["dist-tags"] = new JsonObject
+                {
+                    ["latest"] = Version,
+                },
+                ["versions"] = new JsonObject
+                {
+                    [Version] = new JsonObject
+                    {
+                        ["name"] = PackageName,
+                        ["version"] = Version,
+                        ["dist"] = new JsonObject
+                        {
+                            ["tarball"] = $"https://example.test/{tarballFileName}",
+                        },
+                    },
+                },
+            };
+
+            return Task.FromResult<JsonObject?>(packument);
+        }
+
+        public Task<Stream?> FetchTarballAsync(string tarballUrl, CancellationToken cancellationToken = default) =>
+            Task.FromResult<Stream?>(new MemoryStream([0x1f, 0x8b, 0x08]));
+
+        private static string GetTarballFileName(string packageName, string version)
+        {
+            var shortName = packageName.Contains('@')
+                ? packageName[(packageName.IndexOf('/') + 1)..]
+                : packageName;
+
+            return $"{shortName}-{version}.tgz";
+        }
     }
 }

--- a/tests/AvantiPoint.Packages.Registry.Npm.Tests/NpmRegistryTests.cs
+++ b/tests/AvantiPoint.Packages.Registry.Npm.Tests/NpmRegistryTests.cs
@@ -224,6 +224,8 @@ public class NpmRegistryTests : IClassFixture<NpmTestWebApplicationFactory>
     [Fact]
     public async Task ProxyOnlyMirror_RewritesTarballUrlsThroughFeed()
     {
+        await EnsureDatabaseAsync();
+
         using var factory = _factory.WithWebHostBuilder(builder =>
         {
             builder.ConfigureTestServices(services =>
@@ -245,6 +247,40 @@ public class NpmRegistryTests : IClassFixture<NpmTestWebApplicationFactory>
         var tarballUrl = packument["versions"]![ProxyOnlyNpmMirrorService.Version]!["dist"]!["tarball"]!.GetValue<string>();
         Assert.False(tarballUrl.StartsWith("https://example.test/", StringComparison.OrdinalIgnoreCase));
         Assert.Contains($"/npm/{ProxyOnlyNpmMirrorService.PackageName}/-/{ProxyOnlyNpmMirrorService.PackageName}-{ProxyOnlyNpmMirrorService.Version}.tgz", tarballUrl);
+
+        var tarballResponse = await client.GetAsync(
+            $"/npm/{ProxyOnlyNpmMirrorService.PackageName}/-/{ProxyOnlyNpmMirrorService.PackageName}-{ProxyOnlyNpmMirrorService.Version}.tgz",
+            TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.OK, tarballResponse.StatusCode);
+        Assert.Equal([0x1f, 0x8b, 0x08], await tarballResponse.Content.ReadAsByteArrayAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task IndexAndCacheMirror_WhenNoTarballsPersist_ReturnsNotFoundWithoutRecursiveRetry()
+    {
+        await EnsureDatabaseAsync();
+
+        using var factory = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureTestServices(services =>
+            {
+                services.RemoveAll<INpmMirrorService>();
+                services.AddScoped<INpmMirrorService, MissingTarballNpmMirrorService>();
+            });
+        });
+
+        MissingTarballNpmMirrorService.PackageName = $"missing-tarball-{Guid.NewGuid():N}";
+        MissingTarballNpmMirrorService.Version = "1.0.0";
+        MissingTarballNpmMirrorService.FetchPackumentCalls = 0;
+        MissingTarballNpmMirrorService.FetchTarballCalls = 0;
+        var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", ApiKey);
+
+        var response = await client.GetAsync($"/npm/{MissingTarballNpmMirrorService.PackageName}", TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        Assert.Equal(1, MissingTarballNpmMirrorService.FetchPackumentCalls);
+        Assert.Equal(1, MissingTarballNpmMirrorService.FetchTarballCalls);
     }
 
     [Fact]
@@ -386,6 +422,64 @@ public class NpmRegistryTests : IClassFixture<NpmTestWebApplicationFactory>
 
         public Task<Stream?> FetchTarballAsync(string tarballUrl, CancellationToken cancellationToken = default) =>
             Task.FromResult<Stream?>(new MemoryStream([0x1f, 0x8b, 0x08]));
+
+        private static string GetTarballFileName(string packageName, string version)
+        {
+            var shortName = packageName.Contains('@')
+                ? packageName[(packageName.IndexOf('/') + 1)..]
+                : packageName;
+
+            return $"{shortName}-{version}.tgz";
+        }
+    }
+
+    private sealed class MissingTarballNpmMirrorService : INpmMirrorService
+    {
+        public static string PackageName { get; set; } = string.Empty;
+
+        public static string Version { get; set; } = string.Empty;
+
+        public static int FetchPackumentCalls { get; set; }
+
+        public static int FetchTarballCalls { get; set; }
+
+        public MirrorCachingStrategy Strategy => MirrorCachingStrategy.IndexAndCache;
+
+        public PackageOrigin MirrorOrigin => PackageOrigin.Mirrored;
+
+        public Task<JsonObject?> FetchPackumentAsync(string packageName, CancellationToken cancellationToken = default)
+        {
+            FetchPackumentCalls++;
+            var tarballFileName = GetTarballFileName(PackageName, Version);
+            JsonObject packument = new()
+            {
+                ["name"] = PackageName,
+                ["dist-tags"] = new JsonObject
+                {
+                    ["latest"] = Version,
+                },
+                ["versions"] = new JsonObject
+                {
+                    [Version] = new JsonObject
+                    {
+                        ["name"] = PackageName,
+                        ["version"] = Version,
+                        ["dist"] = new JsonObject
+                        {
+                            ["tarball"] = $"https://example.test/{tarballFileName}",
+                        },
+                    },
+                },
+            };
+
+            return Task.FromResult<JsonObject?>(packument);
+        }
+
+        public Task<Stream?> FetchTarballAsync(string tarballUrl, CancellationToken cancellationToken = default)
+        {
+            FetchTarballCalls++;
+            return Task.FromResult<Stream?>(null);
+        }
 
         private static string GetTarballFileName(string packageName, string version)
         {

--- a/tests/AvantiPoint.Packages.Registry.Npm.Tests/NpmRegistryTests.cs
+++ b/tests/AvantiPoint.Packages.Registry.Npm.Tests/NpmRegistryTests.cs
@@ -325,6 +325,49 @@ public class NpmRegistryTests : IClassFixture<NpmTestWebApplicationFactory>
     }
 
     [Fact]
+    public async Task Publish_WhenRepublishingMirroredVersion_ResetsOriginToPublished()
+    {
+        await EnsureDatabaseAsync();
+        var packageName = $"republish-mirror-{Guid.NewGuid():N}";
+        var version = "1.0.0";
+        FakeNpmMirrorService.PackageName = packageName;
+        FakeNpmMirrorService.Version = version;
+
+        using var factory = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureTestServices(services =>
+            {
+                services.RemoveAll<INpmMirrorService>();
+                services.AddScoped<INpmMirrorService, FakeNpmMirrorService>();
+            });
+        });
+
+        var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", ApiKey);
+        var mirrorResponse = await client.GetAsync($"/npm/{packageName}", TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.OK, mirrorResponse.StatusCode);
+
+        using (var mirrorScope = factory.Services.CreateScope())
+        {
+            var mirrorContext = mirrorScope.ServiceProvider.GetRequiredService<IContext>();
+            var mirroredVersion = mirrorContext.NpmVersions.Single(v => v.Package.Name == packageName && v.Version == version);
+            Assert.Equal(PackageOrigin.Mirrored, mirroredVersion.Origin);
+        }
+
+        var publishBody = BuildNpmPublishBody(packageName, version, tarballBytes: [0x1f, 0x8b, 0x08, 0x09]);
+        var publishResponse = await client.PutAsync(
+            $"/npm/{packageName}",
+            new StringContent(publishBody, Encoding.UTF8, "application/json"),
+            TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.Created, publishResponse.StatusCode);
+
+        using var scope = factory.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<IContext>();
+        var versionEntity = context.NpmVersions.Single(v => v.Package.Name == packageName && v.Version == version);
+        Assert.Equal(PackageOrigin.Published, versionEntity.Origin);
+    }
+
+    [Fact]
     public async Task UnregisteredOciSegment_ReturnsNotFound()
     {
         var client = _factory.CreateClient();

--- a/tests/AvantiPoint.Packages.Registry.Npm.Tests/NpmRegistryTests.cs
+++ b/tests/AvantiPoint.Packages.Registry.Npm.Tests/NpmRegistryTests.cs
@@ -187,6 +187,41 @@ public class NpmRegistryTests : IClassFixture<NpmTestWebApplicationFactory>
     }
 
     [Fact]
+    public async Task Search_UsesLatestDistTagInsteadOfNewestPublishedVersion()
+    {
+        await EnsureDatabaseAsync();
+        var client = CreateAuthenticatedClient();
+        var packageName = $"dist-tag-search-{Guid.NewGuid():N}";
+
+        var stablePublish = await client.PutAsync(
+            $"/npm/{packageName}",
+            new StringContent(BuildNpmPublishBody(packageName, "1.0.0", [0x1f, 0x8b, 0x08]), Encoding.UTF8, "application/json"));
+        Assert.Equal(HttpStatusCode.Created, stablePublish.StatusCode);
+
+        var prereleasePublish = await client.PutAsync(
+            $"/npm/{packageName}",
+            new StringContent(BuildNpmPublishBody(packageName, "2.0.0-beta.1", [0x1f, 0x8b, 0x08]), Encoding.UTF8, "application/json"));
+        Assert.Equal(HttpStatusCode.Created, prereleasePublish.StatusCode);
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var context = scope.ServiceProvider.GetRequiredService<IContext>();
+            var latest = context.NpmDistTags.Single(t => t.FeedId == FeedConstants.DefaultFeedId
+                                                        && t.Package.Name == packageName
+                                                        && t.Tag == "latest");
+            latest.Version = "1.0.0";
+            await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        var response = await client.GetAsync($"/npm/-/v1/search?text={packageName}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var search = JsonNode.Parse(await response.Content.ReadAsStringAsync())!.AsObject();
+        var package = search["objects"]!.AsArray().Single()!["package"]!.AsObject();
+        Assert.Equal("1.0.0", package["version"]!.GetValue<string>());
+    }
+
+    [Fact]
     public async Task MirroringScopedPackage_DoesNotMarkSameTarballNameFromAnotherPackageAsMirrored()
     {
         await EnsureDatabaseAsync();

--- a/tests/AvantiPoint.Packages.Registry.Oci.Tests/OciCatalogDiscoveryTests.cs
+++ b/tests/AvantiPoint.Packages.Registry.Oci.Tests/OciCatalogDiscoveryTests.cs
@@ -1,0 +1,69 @@
+using System.Text;
+using System.Text.Json;
+using AvantiPoint.Packages.Core;
+using AvantiPoint.Packages.Core.Entities.Oci;
+using AvantiPoint.Packages.Registry.Oci.Tests.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace AvantiPoint.Packages.Registry.Oci.Tests;
+
+public sealed class OciCatalogDiscoveryTests : IClassFixture<OciTestWebApplicationFactory>
+{
+    private const string ApiKey = "integration-test-key";
+    private readonly OciTestWebApplicationFactory _factory;
+
+    public OciCatalogDiscoveryTests(OciTestWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task Catalog_ExcludeMirrored_WhenIncludeMirroredInCatalogFalse()
+    {
+        await _factory.EnsureDatabaseMigratedAsync();
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var context = scope.ServiceProvider.GetRequiredService<IContext>();
+
+        var publishedRepo = await SeedRepositoryAsync(context, "published-repo", PackageOrigin.Published);
+        var mirroredRepo = await SeedRepositoryAsync(context, "mirrored-repo", PackageOrigin.Mirrored);
+
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", ApiKey);
+        var response = await client.GetAsync("/v2/_catalog");
+        response.EnsureSuccessStatusCode();
+
+        var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var repos = json.RootElement.GetProperty("repositories")
+            .EnumerateArray()
+            .Select(e => e.GetString())
+            .ToList();
+
+        Assert.Contains(publishedRepo, repos);
+        Assert.DoesNotContain(mirroredRepo, repos);
+    }
+
+    private static async Task<string> SeedRepositoryAsync(IContext context, string name, PackageOrigin origin)
+    {
+        var feedId = "default";
+        var repo = new OciRepository
+        {
+            FeedId = feedId,
+            OciSegment = null,
+            Name = name,
+        };
+        context.OciRepositories.Add(repo);
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        context.OciTags.Add(new OciTag
+        {
+            FeedId = feedId,
+            OciSegment = null,
+            RepositoryKey = repo.Key,
+            Tag = "latest",
+            ManifestDigest = "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+            Origin = origin,
+        });
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+        return name;
+    }
+}

--- a/tests/AvantiPoint.Packages.Registry.Oci.Tests/OciMirrorServiceTests.cs
+++ b/tests/AvantiPoint.Packages.Registry.Oci.Tests/OciMirrorServiceTests.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Headers;
 using AvantiPoint.Feed.Platform;
 using AvantiPoint.Feed.Platform.Configuration;
 using AvantiPoint.Feed.Platform.Mirror;
+using AvantiPoint.Packages.Core;
 using AvantiPoint.Packages.Registry.Oci;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -153,15 +154,29 @@ public sealed class OciMirrorServiceTests
         Assert.Equal(0, tokenRequests);
     }
 
+    [Fact]
+    public void MirrorOrigin_MapsCacheOnlyMirrorsToCachedOrigin()
+    {
+        var service = CreateService(
+            new CaptureRequestHandler(_ => new HttpResponseMessage(HttpStatusCode.NotFound)),
+            strategy: MirrorCachingStrategy.CacheOnly);
+
+        var origin = service.MirrorOrigin(CreateSurface());
+
+        Assert.Equal(PackageOrigin.Cached, origin);
+    }
+
     private static OciMirrorService CreateService(
         HttpMessageHandler handler,
         string? username = null,
-        string? password = null)
+        string? password = null,
+        MirrorCachingStrategy strategy = MirrorCachingStrategy.IndexAndCache)
     {
         var options = new OciFeedOptions
         {
             Mirror = new OciMirrorOptions
             {
+                CachingStrategy = strategy,
                 Registries =
                 [
                     new OciUpstreamRegistryOptions
@@ -176,9 +191,13 @@ public sealed class OciMirrorServiceTests
         };
 
         var accessor = new OciFeedOptionsAccessor(new TestOptionsMonitor<OciFeedOptions>(options));
+        var policy = new ConfigurableMirrorPolicyService(
+            Options.Create(new SearchOptions()),
+            Options.Create(new NpmFeedOptions()),
+            new TestOptionsMonitor<OciFeedOptions>(options));
         return new OciMirrorService(
             accessor,
-            new DefaultMirrorPolicyService(),
+            policy,
             new SingleClientHttpClientFactory(new HttpClient(handler)),
             NullLogger<OciMirrorService>.Instance);
     }

--- a/tests/AvantiPoint.Packages.Registry.Oci.Tests/OciMirrorServiceTests.cs
+++ b/tests/AvantiPoint.Packages.Registry.Oci.Tests/OciMirrorServiceTests.cs
@@ -155,6 +155,124 @@ public sealed class OciMirrorServiceTests
     }
 
     [Fact]
+    public async Task TryFetchManifestAsync_TriesLowerPriorityRegistryAfterMiss()
+    {
+        var requestedHosts = new List<string>();
+        var handler = new CaptureRequestHandler(request =>
+        {
+            requestedHosts.Add(request.RequestUri?.Host ?? string.Empty);
+            if (request.RequestUri?.Host == "primary.example")
+            {
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
+            }
+
+            if (request.RequestUri?.Host == "secondary.example")
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Headers = { { "Docker-Content-Digest", "sha256:fallback" } },
+                    Content = new StringContent(
+                        "{}",
+                        new MediaTypeHeaderValue("application/vnd.oci.image.manifest.v1+json")),
+                };
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.BadGateway);
+        });
+
+        var service = CreateService(handler, registries: CreateFallbackRegistries());
+        var surface = CreateSurface();
+
+        var result = await service.TryFetchManifestAsync(
+            surface,
+            "library/nginx",
+            "latest",
+            TestContext.Current.CancellationToken);
+
+        Assert.NotNull(result);
+        Assert.Equal("sha256:fallback", result.Digest);
+        Assert.Equal(new[] { "primary.example", "secondary.example" }, requestedHosts);
+    }
+
+    [Fact]
+    public async Task TryFetchBlobAsync_TriesLowerPriorityRegistryAfterMiss()
+    {
+        var requestedHosts = new List<string>();
+        var handler = new CaptureRequestHandler(request =>
+        {
+            requestedHosts.Add(request.RequestUri?.Host ?? string.Empty);
+            if (request.RequestUri?.Host == "primary.example")
+            {
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
+            }
+
+            if (request.RequestUri?.Host == "secondary.example")
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new ByteArrayContent([1, 2, 3]),
+                };
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.BadGateway);
+        });
+
+        var service = CreateService(handler, registries: CreateFallbackRegistries());
+        var surface = CreateSurface();
+
+        await using var stream = await service.TryFetchBlobAsync(
+            surface,
+            "library/nginx",
+            "sha256:abc",
+            TestContext.Current.CancellationToken);
+
+        Assert.NotNull(stream);
+        Assert.Equal(3, stream!.Length);
+        Assert.Equal(new[] { "primary.example", "secondary.example" }, requestedHosts);
+    }
+
+    [Fact]
+    public async Task TryCheckBlobExistsAsync_TriesLowerPriorityRegistryAfterMiss()
+    {
+        var requestedHosts = new List<string>();
+        var handler = new CaptureRequestHandler(request =>
+        {
+            requestedHosts.Add(request.RequestUri?.Host ?? string.Empty);
+            if (request.RequestUri?.Host == "primary.example")
+            {
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
+            }
+
+            if (request.RequestUri?.Host == "secondary.example")
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new ByteArrayContent([])
+                    {
+                        Headers = { ContentLength = 42 },
+                    },
+                };
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.BadGateway);
+        });
+
+        var service = CreateService(handler, registries: CreateFallbackRegistries());
+        var surface = CreateSurface();
+
+        var result = await service.TryCheckBlobExistsAsync(
+            surface,
+            "library/nginx",
+            "sha256:abc",
+            TestContext.Current.CancellationToken);
+
+        Assert.NotNull(result);
+        Assert.True(result.Exists);
+        Assert.Equal(42, result.Size);
+        Assert.Equal(new[] { "primary.example", "secondary.example" }, requestedHosts);
+    }
+
+    [Fact]
     public void MirrorOrigin_MapsCacheOnlyMirrorsToCachedOrigin()
     {
         var service = CreateService(
@@ -170,14 +288,15 @@ public sealed class OciMirrorServiceTests
         HttpMessageHandler handler,
         string? username = null,
         string? password = null,
-        MirrorCachingStrategy strategy = MirrorCachingStrategy.IndexAndCache)
+        MirrorCachingStrategy strategy = MirrorCachingStrategy.IndexAndCache,
+        IEnumerable<OciUpstreamRegistryOptions>? registries = null)
     {
         var options = new OciFeedOptions
         {
             Mirror = new OciMirrorOptions
             {
                 CachingStrategy = strategy,
-                Registries =
+                Registries = registries?.ToList() ??
                 [
                     new OciUpstreamRegistryOptions
                     {
@@ -210,6 +329,12 @@ public sealed class OciMirrorServiceTests
             null,
             "/v2",
             new Uri("https://feed.example/v2/"));
+
+    private static IReadOnlyList<OciUpstreamRegistryOptions> CreateFallbackRegistries() =>
+    [
+        new OciUpstreamRegistryOptions { Url = "https://secondary.example", Priority = 20 },
+        new OciUpstreamRegistryOptions { Url = "https://primary.example", Priority = 10 },
+    ];
 
     private static HttpRequestMessage CloneRequest(HttpRequestMessage request)
     {

--- a/tests/AvantiPoint.Packages.Registry.Oci.Tests/OciMirrorServiceTests.cs
+++ b/tests/AvantiPoint.Packages.Registry.Oci.Tests/OciMirrorServiceTests.cs
@@ -27,31 +27,8 @@ public sealed class OciMirrorServiceTests
             };
         });
 
-        var options = new OciFeedOptions
-        {
-            Mirror = new OciMirrorOptions
-            {
-                Registries =
-                [
-                    new OciUpstreamRegistryOptions { Url = "https://registry.example", Priority = 0 },
-                ],
-            },
-        };
-
-        var accessor = new OciFeedOptionsAccessor(new TestOptionsMonitor<OciFeedOptions>(options));
-        var service = new OciMirrorService(
-            accessor,
-            new DefaultMirrorPolicyService(),
-            new SingleClientHttpClientFactory(new HttpClient(handler)),
-            NullLogger<OciMirrorService>.Instance);
-
-        var surface = new SurfaceContext(
-            "default",
-            FeedProtocol.Oci,
-            "default",
-            null,
-            "/v2",
-            new Uri("https://feed.example/v2/"));
+        var service = CreateService(handler);
+        var surface = CreateSurface();
 
         var result = await service.TryFetchManifestAsync(
             surface,
@@ -64,6 +41,186 @@ public sealed class OciMirrorServiceTests
         var accept = captured!.Headers.Accept.Select(h => h.MediaType).ToList();
         Assert.Contains("application/vnd.oci.image.index.v1+json", accept);
         Assert.Contains("application/vnd.docker.distribution.manifest.list.v2+json", accept);
+    }
+
+    [Fact]
+    public async Task TryFetchManifestAsync_FollowsBearerChallengeAndRetriesWithToken()
+    {
+        var requests = new List<HttpRequestMessage>();
+        var handler = new CaptureRequestHandler(request =>
+        {
+            requests.Add(CloneRequest(request));
+            if (request.RequestUri?.AbsolutePath == "/v2/library/nginx/manifests/latest")
+            {
+                if (request.Headers.Authorization?.Scheme == "Bearer")
+                {
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Headers = { { "Docker-Content-Digest", "sha256:abc" } },
+                        Content = new StringContent(
+                            "{}",
+                            new MediaTypeHeaderValue("application/vnd.oci.image.manifest.v1+json")),
+                    };
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.Unauthorized)
+                {
+                    Headers =
+                    {
+                        WwwAuthenticate =
+                        {
+                            new AuthenticationHeaderValue(
+                                "Bearer",
+                                "realm=\"https://registry.example/token\",service=\"registry.example\",scope=\"repository:library/nginx:pull\""),
+                        },
+                    },
+                };
+            }
+
+            if (request.RequestUri?.AbsolutePath == "/token")
+            {
+                Assert.Equal("Basic", request.Headers.Authorization?.Scheme);
+                Assert.Equal("registry.example", QueryParameter(request.RequestUri, "service"));
+                Assert.Equal("repository:library/nginx:pull", QueryParameter(request.RequestUri, "scope"));
+
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"token\":\"mirror-token\"}"),
+                };
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        });
+
+        var service = CreateService(handler, username: "mirror-user", password: "mirror-pass");
+        var surface = CreateSurface();
+
+        var result = await service.TryFetchManifestAsync(
+            surface,
+            "library/nginx",
+            "latest",
+            TestContext.Current.CancellationToken);
+
+        Assert.NotNull(result);
+        Assert.Equal("sha256:abc", result.Digest);
+        Assert.Equal(3, requests.Count);
+        Assert.Equal("Basic", requests[0].Headers.Authorization?.Scheme);
+        Assert.Equal("Basic", requests[1].Headers.Authorization?.Scheme);
+        Assert.Equal("Bearer", requests[2].Headers.Authorization?.Scheme);
+        Assert.Equal("mirror-token", requests[2].Headers.Authorization?.Parameter);
+    }
+
+    [Fact]
+    public async Task TryFetchManifestAsync_DoesNotSendBasicCredentialsToInsecureTokenRealm()
+    {
+        var tokenRequests = 0;
+        var handler = new CaptureRequestHandler(request =>
+        {
+            if (request.RequestUri?.AbsolutePath == "/v2/library/nginx/manifests/latest")
+            {
+                return new HttpResponseMessage(HttpStatusCode.Unauthorized)
+                {
+                    Headers =
+                    {
+                        WwwAuthenticate =
+                        {
+                            new AuthenticationHeaderValue(
+                                "Bearer",
+                                "realm=\"http://registry.example/token\",service=\"registry.example\",scope=\"repository:library/nginx:pull\""),
+                        },
+                    },
+                };
+            }
+
+            if (request.RequestUri?.AbsolutePath == "/token")
+            {
+                tokenRequests++;
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        });
+
+        var service = CreateService(handler, username: "mirror-user", password: "mirror-pass");
+        var surface = CreateSurface();
+
+        var result = await service.TryFetchManifestAsync(
+            surface,
+            "library/nginx",
+            "latest",
+            TestContext.Current.CancellationToken);
+
+        Assert.Null(result);
+        Assert.Equal(0, tokenRequests);
+    }
+
+    private static OciMirrorService CreateService(
+        HttpMessageHandler handler,
+        string? username = null,
+        string? password = null)
+    {
+        var options = new OciFeedOptions
+        {
+            Mirror = new OciMirrorOptions
+            {
+                Registries =
+                [
+                    new OciUpstreamRegistryOptions
+                    {
+                        Url = "https://registry.example",
+                        Priority = 0,
+                        Username = username,
+                        Password = password,
+                    },
+                ],
+            },
+        };
+
+        var accessor = new OciFeedOptionsAccessor(new TestOptionsMonitor<OciFeedOptions>(options));
+        return new OciMirrorService(
+            accessor,
+            new DefaultMirrorPolicyService(),
+            new SingleClientHttpClientFactory(new HttpClient(handler)),
+            NullLogger<OciMirrorService>.Instance);
+    }
+
+    private static SurfaceContext CreateSurface() =>
+        new(
+            "default",
+            FeedProtocol.Oci,
+            "default",
+            null,
+            "/v2",
+            new Uri("https://feed.example/v2/"));
+
+    private static HttpRequestMessage CloneRequest(HttpRequestMessage request)
+    {
+        var clone = new HttpRequestMessage(request.Method, request.RequestUri);
+        foreach (var header in request.Headers)
+        {
+            clone.Headers.TryAddWithoutValidation(header.Key, header.Value);
+        }
+
+        return clone;
+    }
+
+    private static string? QueryParameter(Uri? uri, string key)
+    {
+        if (uri is null)
+        {
+            return null;
+        }
+
+        var query = uri.Query.TrimStart('?').Split('&', StringSplitOptions.RemoveEmptyEntries);
+        foreach (var item in query)
+        {
+            var parts = item.Split('=', 2);
+            if (parts.Length == 2 && Uri.UnescapeDataString(parts[0]) == key)
+            {
+                return Uri.UnescapeDataString(parts[1]);
+            }
+        }
+
+        return null;
     }
 
     private sealed class CaptureRequestHandler(Func<HttpRequestMessage, HttpResponseMessage> responder)

--- a/tests/AvantiPoint.Packages.Registry.Oci.Tests/OciMirrorServiceTests.cs
+++ b/tests/AvantiPoint.Packages.Registry.Oci.Tests/OciMirrorServiceTests.cs
@@ -1,0 +1,92 @@
+using System.Net;
+using System.Net.Http.Headers;
+using AvantiPoint.Feed.Platform;
+using AvantiPoint.Feed.Platform.Configuration;
+using AvantiPoint.Feed.Platform.Mirror;
+using AvantiPoint.Packages.Registry.Oci;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace AvantiPoint.Packages.Registry.Oci.Tests;
+
+public sealed class OciMirrorServiceTests
+{
+    [Fact]
+    public async Task TryFetchManifestAsync_AdvertisesIndexMediaTypes()
+    {
+        HttpRequestMessage? captured = null;
+        var handler = new CaptureRequestHandler(request =>
+        {
+            captured = request;
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Headers = { { "Docker-Content-Digest", "sha256:abc" } },
+                Content = new StringContent(
+                    "{}",
+                    new MediaTypeHeaderValue("application/vnd.oci.image.index.v1+json")),
+            };
+        });
+
+        var options = new OciFeedOptions
+        {
+            Mirror = new OciMirrorOptions
+            {
+                Registries =
+                [
+                    new OciUpstreamRegistryOptions { Url = "https://registry.example", Priority = 0 },
+                ],
+            },
+        };
+
+        var accessor = new OciFeedOptionsAccessor(new TestOptionsMonitor<OciFeedOptions>(options));
+        var service = new OciMirrorService(
+            accessor,
+            new DefaultMirrorPolicyService(),
+            new SingleClientHttpClientFactory(new HttpClient(handler)),
+            NullLogger<OciMirrorService>.Instance);
+
+        var surface = new SurfaceContext(
+            "default",
+            FeedProtocol.Oci,
+            "default",
+            null,
+            "/v2",
+            new Uri("https://feed.example/v2/"));
+
+        var result = await service.TryFetchManifestAsync(
+            surface,
+            "library/nginx",
+            "latest",
+            TestContext.Current.CancellationToken);
+
+        Assert.NotNull(result);
+        Assert.NotNull(captured);
+        var accept = captured!.Headers.Accept.Select(h => h.MediaType).ToList();
+        Assert.Contains("application/vnd.oci.image.index.v1+json", accept);
+        Assert.Contains("application/vnd.docker.distribution.manifest.list.v2+json", accept);
+    }
+
+    private sealed class CaptureRequestHandler(Func<HttpRequestMessage, HttpResponseMessage> responder)
+        : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) =>
+            Task.FromResult(responder(request));
+    }
+
+    private sealed class SingleClientHttpClientFactory(HttpClient client) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => client;
+    }
+
+    private sealed class TestOptionsMonitor<T>(T value) : IOptionsMonitor<T>
+        where T : class
+    {
+        public T CurrentValue => value;
+
+        public T Get(string? name) => value;
+
+        public IDisposable? OnChange(Action<T, string?> listener) => null;
+    }
+}

--- a/tests/AvantiPoint.Packages.Registry.Oci.Tests/OciRegistryTests.cs
+++ b/tests/AvantiPoint.Packages.Registry.Oci.Tests/OciRegistryTests.cs
@@ -7,6 +7,7 @@ using AvantiPoint.Feed.Platform;
 using AvantiPoint.Feed.Platform.Configuration;
 using AvantiPoint.Feed.Platform.Mirror;
 using AvantiPoint.Packages.Core;
+using AvantiPoint.Packages.Core.Entities.Oci;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -296,6 +297,65 @@ public class OciRegistryTests : IClassFixture<OciTestWebApplicationFactory>
     }
 
     [Fact]
+    public async Task MirroredBlobGet_FallsBackToUpstreamWhenLocalBlobRecordHasNoFile()
+    {
+        var blobContent = Encoding.UTF8.GetBytes("upstream-layer");
+        var blobDigest = ComputeDigest(blobContent);
+        var manifest = $$"""
+                         {
+                           "schemaVersion": 2,
+                           "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                           "config": {
+                             "mediaType": "application/vnd.oci.empty.v1+json",
+                             "size": {{blobContent.Length}},
+                             "digest": "{{blobDigest}}"
+                           },
+                           "layers": []
+                         }
+                         """;
+        var manifestBytes = Encoding.UTF8.GetBytes(manifest);
+        var upstream = new OciUpstreamManifest(
+            ComputeDigest(manifestBytes),
+            "application/vnd.oci.image.manifest.v1+json",
+            manifestBytes);
+
+        var mirror = new TestOciMirrorService(upstream, blobDigest, blobContent);
+        using var factory = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                services.RemoveAll<IOciMirrorService>();
+                services.AddSingleton<IOciMirrorService>(mirror);
+            });
+        });
+
+        await EnsureDatabaseAsync(factory);
+        var repository = $"mirror/{Guid.NewGuid():N}";
+        var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", ApiKey);
+
+        var manifestResponse = await client.GetAsync($"/v2/{repository}/manifests/v1");
+        Assert.Equal(HttpStatusCode.OK, manifestResponse.StatusCode);
+
+        using (var scope = factory.Services.CreateScope())
+        {
+            var context = scope.ServiceProvider.GetRequiredService<IContext>();
+            context.OciBlobs.Add(new OciBlob
+            {
+                Digest = blobDigest,
+                Size = blobContent.Length,
+            });
+            await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        var blobResponse = await client.GetAsync($"/v2/{repository}/blobs/{blobDigest}");
+
+        Assert.Equal(HttpStatusCode.OK, blobResponse.StatusCode);
+        Assert.Equal(blobContent, await blobResponse.Content.ReadAsByteArrayAsync());
+        Assert.Equal(1, mirror.FetchBlobCalls);
+    }
+
+    [Fact]
     public async Task NuGetRoutes_AreNotCapturedByOci()
     {
         var client = _factory.CreateClient();
@@ -342,9 +402,14 @@ public class OciRegistryTests : IClassFixture<OciTestWebApplicationFactory>
         return digest;
     }
 
-    private sealed class TestOciMirrorService(OciUpstreamManifest manifest) : IOciMirrorService
+    private sealed class TestOciMirrorService(
+        OciUpstreamManifest manifest,
+        string? blobDigest = null,
+        byte[]? blobContent = null) : IOciMirrorService
     {
         public int FetchManifestCalls { get; private set; }
+
+        public int FetchBlobCalls { get; private set; }
 
         public Task<OciUpstreamManifest?> TryFetchManifestAsync(
             SurfaceContext surface,
@@ -360,8 +425,16 @@ public class OciRegistryTests : IClassFixture<OciTestWebApplicationFactory>
             SurfaceContext surface,
             string repositoryName,
             string digest,
-            CancellationToken cancellationToken = default) =>
-            Task.FromResult<Stream?>(null);
+            CancellationToken cancellationToken = default)
+        {
+            if (!string.Equals(digest, blobDigest, StringComparison.OrdinalIgnoreCase) || blobContent is null)
+            {
+                return Task.FromResult<Stream?>(null);
+            }
+
+            FetchBlobCalls++;
+            return Task.FromResult<Stream?>(new MemoryStream(blobContent));
+        }
 
         public Task<OciBlobExistsResult?> TryCheckBlobExistsAsync(
             SurfaceContext surface,

--- a/tests/AvantiPoint.Packages.Registry.Oci.Tests/OciRegistryTests.cs
+++ b/tests/AvantiPoint.Packages.Registry.Oci.Tests/OciRegistryTests.cs
@@ -3,10 +3,14 @@ using System.Net.Http.Headers;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
+using AvantiPoint.Feed.Platform;
+using AvantiPoint.Feed.Platform.Configuration;
+using AvantiPoint.Feed.Platform.Mirror;
 using AvantiPoint.Packages.Core;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Xunit;
 
@@ -237,6 +241,61 @@ public class OciRegistryTests : IClassFixture<OciTestWebApplicationFactory>
     }
 
     [Fact]
+    public async Task MirroredManifestGet_PersistsManifestWithoutLocalReferencedBlobs()
+    {
+        var referencedConfigDigest = ComputeDigest(Encoding.UTF8.GetBytes("upstream-config"));
+        var referencedLayerDigest = ComputeDigest(Encoding.UTF8.GetBytes("upstream-layer"));
+        var manifest = $$"""
+                         {
+                           "schemaVersion": 2,
+                           "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                           "config": {
+                             "mediaType": "application/vnd.oci.empty.v1+json",
+                             "size": 15,
+                             "digest": "{{referencedConfigDigest}}"
+                           },
+                           "layers": [
+                             {
+                               "mediaType": "application/vnd.oci.image.layer.v1.tar",
+                               "size": 14,
+                               "digest": "{{referencedLayerDigest}}"
+                             }
+                           ]
+                         }
+                         """;
+        var manifestBytes = Encoding.UTF8.GetBytes(manifest);
+        var upstream = new OciUpstreamManifest(
+            ComputeDigest(manifestBytes),
+            "application/vnd.oci.image.manifest.v1+json",
+            manifestBytes);
+
+        var mirror = new TestOciMirrorService(upstream);
+        using var factory = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                services.RemoveAll<IOciMirrorService>();
+                services.AddSingleton<IOciMirrorService>(mirror);
+            });
+        });
+
+        await EnsureDatabaseAsync(factory);
+        var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", ApiKey);
+
+        var repository = $"mirror/{Guid.NewGuid():N}";
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var response = await client.GetAsync($"/v2/{repository}/manifests/v1", cancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(upstream.Digest, response.Headers.GetValues("Docker-Content-Digest").Single());
+
+        var secondResponse = await client.GetAsync($"/v2/{repository}/manifests/v1", cancellationToken);
+        Assert.Equal(HttpStatusCode.OK, secondResponse.StatusCode);
+        Assert.Equal(1, mirror.FetchManifestCalls);
+    }
+
+    [Fact]
     public async Task NuGetRoutes_AreNotCapturedByOci()
     {
         var client = _factory.CreateClient();
@@ -245,6 +304,13 @@ public class OciRegistryTests : IClassFixture<OciTestWebApplicationFactory>
     }
 
     private async Task EnsureDatabaseAsync() => await _factory.EnsureDatabaseMigratedAsync();
+
+    private static async Task EnsureDatabaseAsync(WebApplicationFactory<IntegrationTestApi.Program> factory)
+    {
+        using var scope = factory.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<IContext>();
+        await context.RunMigrationsAsync(TestContext.Current.CancellationToken);
+    }
 
     private HttpClient CreateAuthenticatedClient()
     {
@@ -274,5 +340,40 @@ public class OciRegistryTests : IClassFixture<OciTestWebApplicationFactory>
         var completeResponse = await client.PutAsync($"{location}?digest={Uri.EscapeDataString(digest)}", null);
         completeResponse.EnsureSuccessStatusCode();
         return digest;
+    }
+
+    private sealed class TestOciMirrorService(OciUpstreamManifest manifest) : IOciMirrorService
+    {
+        public int FetchManifestCalls { get; private set; }
+
+        public Task<OciUpstreamManifest?> TryFetchManifestAsync(
+            SurfaceContext surface,
+            string repositoryName,
+            string reference,
+            CancellationToken cancellationToken = default)
+        {
+            FetchManifestCalls++;
+            return Task.FromResult<OciUpstreamManifest?>(manifest);
+        }
+
+        public Task<Stream?> TryFetchBlobAsync(
+            SurfaceContext surface,
+            string repositoryName,
+            string digest,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult<Stream?>(null);
+
+        public Task<OciBlobExistsResult?> TryCheckBlobExistsAsync(
+            SurfaceContext surface,
+            string repositoryName,
+            string digest,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult<OciBlobExistsResult?>(null);
+
+        public PackageOrigin MirrorOrigin(SurfaceContext surface) => PackageOrigin.Mirrored;
+
+        public MirrorCachingStrategy Strategy(SurfaceContext surface) => MirrorCachingStrategy.IndexAndCache;
+
+        public bool ShouldPersist(SurfaceContext surface) => true;
     }
 }

--- a/tests/AvantiPoint.Packages.Registry.Oci.Tests/OciRegistryTests.cs
+++ b/tests/AvantiPoint.Packages.Registry.Oci.Tests/OciRegistryTests.cs
@@ -356,6 +356,59 @@ public class OciRegistryTests : IClassFixture<OciTestWebApplicationFactory>
     }
 
     [Fact]
+    public async Task MirroredBlobGet_RejectsUpstreamContentWithMismatchedDigest()
+    {
+        var validBlobContent = Encoding.UTF8.GetBytes($"upstream-layer-{Guid.NewGuid():N}");
+        var blobDigest = ComputeDigest(validBlobContent);
+        var corruptBlobContent = Encoding.UTF8.GetBytes($"corrupt-upstream-layer-{Guid.NewGuid():N}");
+        var manifest = $$"""
+                         {
+                           "schemaVersion": 2,
+                           "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                           "config": {
+                             "mediaType": "application/vnd.oci.empty.v1+json",
+                             "size": {{validBlobContent.Length}},
+                             "digest": "{{blobDigest}}"
+                           },
+                           "layers": []
+                         }
+                         """;
+        var manifestBytes = Encoding.UTF8.GetBytes(manifest);
+        var upstream = new OciUpstreamManifest(
+            ComputeDigest(manifestBytes),
+            "application/vnd.oci.image.manifest.v1+json",
+            manifestBytes);
+
+        var mirror = new TestOciMirrorService(upstream, blobDigest, corruptBlobContent);
+        using var factory = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                services.RemoveAll<IOciMirrorService>();
+                services.AddSingleton<IOciMirrorService>(mirror);
+            });
+        });
+
+        await EnsureDatabaseAsync(factory);
+        var repository = $"mirror/{Guid.NewGuid():N}";
+        var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", ApiKey);
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        var manifestResponse = await client.GetAsync($"/v2/{repository}/manifests/v1", cancellationToken);
+        Assert.Equal(HttpStatusCode.OK, manifestResponse.StatusCode);
+
+        var blobResponse = await client.GetAsync($"/v2/{repository}/blobs/{blobDigest}", cancellationToken);
+
+        Assert.Equal(HttpStatusCode.NotFound, blobResponse.StatusCode);
+        Assert.Equal(1, mirror.FetchBlobCalls);
+
+        using var scope = factory.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<IContext>();
+        Assert.False(context.OciBlobs.Any(b => b.Digest == blobDigest));
+    }
+
+    [Fact]
     public async Task NuGetRoutes_AreNotCapturedByOci()
     {
         var client = _factory.CreateClient();

--- a/tests/AvantiPoint.Packages.Search.Tests/PackageOriginDiscoveryIntegrationTests.cs
+++ b/tests/AvantiPoint.Packages.Search.Tests/PackageOriginDiscoveryIntegrationTests.cs
@@ -197,6 +197,52 @@ public sealed class PackageOriginDiscoveryIntegrationTests : IDisposable
         Assert.Equal(["Scoped.High", "Scoped.Low"], response.Data);
     }
 
+    [Fact]
+    public async Task FindDependents_UsesCurrentFeedDownloadCountsOnly()
+    {
+        var current = new Package
+        {
+            FeedId = FeedConstants.DefaultFeedId,
+            Id = "Dependent.One",
+            Version = NuGetVersion.Parse("1.0.0"),
+            Description = "current feed dependent",
+            Listed = true,
+            Published = DateTime.UtcNow,
+            Origin = PackageOrigin.Published,
+            Dependencies = [new PackageDependency { Id = "Root.Package" }],
+        };
+        var otherFeed = new Package
+        {
+            FeedId = "other-feed",
+            Id = "Dependent.One",
+            Version = NuGetVersion.Parse("1.0.0"),
+            Description = "other feed dependent",
+            Listed = true,
+            Published = DateTime.UtcNow,
+            Origin = PackageOrigin.Published,
+            Dependencies = [new PackageDependency { Id = "Root.Package" }],
+        };
+
+        _context.Packages.AddRange(current, otherFeed);
+        await _context.SaveChangesAsync();
+
+        _context.PackageDownloads.Add(new PackageDownload { PackageKey = current.Key });
+        for (var i = 0; i < 5; i++)
+        {
+            _context.PackageDownloads.Add(new PackageDownload { PackageKey = otherFeed.Key });
+        }
+        await _context.SaveChangesAsync();
+
+        var search = CreateSearchService(includeMirrored: true);
+
+        var response = await search.FindDependentsAsync("Root.Package", CancellationToken.None);
+
+        var result = Assert.Single(response.Data);
+        Assert.Equal("Dependent.One", result.Id);
+        Assert.Equal("current feed dependent", result.Description);
+        Assert.Equal(1, result.TotalDownloads);
+    }
+
     private DatabaseSearchService CreateSearchService(bool includeMirrored)
     {
         return new DatabaseSearchService(

--- a/tests/AvantiPoint.Packages.Search.Tests/PackageOriginDiscoveryIntegrationTests.cs
+++ b/tests/AvantiPoint.Packages.Search.Tests/PackageOriginDiscoveryIntegrationTests.cs
@@ -145,7 +145,8 @@ public sealed class PackageOriginDiscoveryIntegrationTests : IDisposable
             _context,
             new FrameworkCompatibilityService(),
             new TestUrlGenerator(),
-            Options.Create(new SearchOptions { IncludeMirroredPackages = includeMirrored }));
+            Options.Create(new SearchOptions { IncludeMirroredPackages = includeMirrored }),
+            new DefaultFeedScope());
     }
 
     public void Dispose()

--- a/tests/AvantiPoint.Packages.Search.Tests/PackageOriginDiscoveryIntegrationTests.cs
+++ b/tests/AvantiPoint.Packages.Search.Tests/PackageOriginDiscoveryIntegrationTests.cs
@@ -139,6 +139,64 @@ public sealed class PackageOriginDiscoveryIntegrationTests : IDisposable
         Assert.DoesNotContain(response.Data, p => p.PackageId == "Cached.Only");
     }
 
+    [Fact]
+    public async Task Autocomplete_OrdersByCurrentFeedDownloadCountsOnly()
+    {
+        var lowCurrent = new Package
+        {
+            FeedId = FeedConstants.DefaultFeedId,
+            Id = "Scoped.Low",
+            Version = NuGetVersion.Parse("1.0.0"),
+            Listed = true,
+            Published = DateTime.UtcNow,
+            Origin = PackageOrigin.Published,
+        };
+        var highCurrent = new Package
+        {
+            FeedId = FeedConstants.DefaultFeedId,
+            Id = "Scoped.High",
+            Version = NuGetVersion.Parse("1.0.0"),
+            Listed = true,
+            Published = DateTime.UtcNow,
+            Origin = PackageOrigin.Published,
+        };
+        var lowOtherFeed = new Package
+        {
+            FeedId = "other-feed",
+            Id = "Scoped.Low",
+            Version = NuGetVersion.Parse("1.0.0"),
+            Listed = true,
+            Published = DateTime.UtcNow,
+            Origin = PackageOrigin.Published,
+        };
+
+        _context.Packages.AddRange(lowCurrent, highCurrent, lowOtherFeed);
+        await _context.SaveChangesAsync();
+
+        _context.PackageDownloads.Add(new PackageDownload { PackageKey = highCurrent.Key });
+        for (var i = 0; i < 5; i++)
+        {
+            _context.PackageDownloads.Add(new PackageDownload { PackageKey = lowOtherFeed.Key });
+        }
+        await _context.SaveChangesAsync();
+
+        var search = CreateSearchService(includeMirrored: true);
+
+        var response = await search.AutocompleteAsync(
+            new AutocompleteRequest
+            {
+                Query = "Scoped",
+                Take = 20,
+                Skip = 0,
+                IncludePrerelease = true,
+                IncludeSemVer2 = true,
+            },
+            CancellationToken.None);
+
+        Assert.Equal(2, response.TotalHits);
+        Assert.Equal(["Scoped.High", "Scoped.Low"], response.Data);
+    }
+
     private DatabaseSearchService CreateSearchService(bool includeMirrored)
     {
         return new DatabaseSearchService(

--- a/tests/AvantiPoint.Packages.Tests/Metadata/DefaultPackageMetadataServiceTests.cs
+++ b/tests/AvantiPoint.Packages.Tests/Metadata/DefaultPackageMetadataServiceTests.cs
@@ -40,7 +40,8 @@ public class DefaultPackageMetadataServiceTests
             packages.Object,
             new RegistrationBuilder(Mock.Of<IUrlGenerator>()),
             Mock.Of<IUrlGenerator>(),
-            Options.Create(new SearchOptions { IncludeMirroredPackages = false }));
+            Options.Create(new SearchOptions { IncludeMirroredPackages = false }),
+            new DefaultFeedScope());
 
         var result = await service.GetRegistrationIndexOrNullAsync(
             "Upstream.Only",

--- a/tests/AvantiPoint.Packages.Tests/PackageServiceFeedScopeTests.cs
+++ b/tests/AvantiPoint.Packages.Tests/PackageServiceFeedScopeTests.cs
@@ -1,0 +1,82 @@
+using AvantiPoint.Packages.Core;
+using AvantiPoint.Packages.Database.Sqlite;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using NuGet.Versioning;
+
+namespace AvantiPoint.Packages.Tests;
+
+public sealed class PackageServiceFeedScopeTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly SqliteContext _context;
+
+    public PackageServiceFeedScopeTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        var options = new DbContextOptionsBuilder<SqliteContext>()
+            .UseSqlite(_connection)
+            .Options;
+
+        _context = new SqliteContext(options);
+        _context.Database.EnsureCreated();
+    }
+
+    [Fact]
+    public async Task HardDeletePackageAsync_DeletesOnlyCurrentFeedPackage()
+    {
+        var version = NuGetVersion.Parse("1.0.0");
+        _context.Packages.AddRange(
+            CreatePackage("other-feed", "Shared.Package", version),
+            CreatePackage(FeedConstants.DefaultFeedId, "Shared.Package", version));
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var service = new PackageService(
+            _context,
+            new HttpContextAccessor(),
+            CreateFeedScope(FeedConstants.DefaultFeedId));
+
+        var deleted = await service.HardDeletePackageAsync(
+            "Shared.Package",
+            version,
+            TestContext.Current.CancellationToken);
+
+        Assert.True(deleted);
+        Assert.False(await _context.Packages.AnyAsync(
+            p => p.FeedId == FeedConstants.DefaultFeedId && p.Id == "Shared.Package",
+            TestContext.Current.CancellationToken));
+        Assert.True(await _context.Packages.AnyAsync(
+            p => p.FeedId == "other-feed" && p.Id == "Shared.Package",
+            TestContext.Current.CancellationToken));
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        _connection.Dispose();
+    }
+
+    private static IFeedScope CreateFeedScope(string feedId)
+    {
+        var feedScope = new Mock<IFeedScope>();
+        feedScope.Setup(s => s.FeedId).Returns(feedId);
+        return feedScope.Object;
+    }
+
+    private static Package CreatePackage(string feedId, string id, NuGetVersion version)
+    {
+        return new Package
+        {
+            FeedId = feedId,
+            Id = id,
+            Version = version,
+            Listed = true,
+            Published = DateTime.UtcNow,
+            Origin = PackageOrigin.Published,
+        };
+    }
+}

--- a/tests/TestAssets/global.json
+++ b/tests/TestAssets/global.json
@@ -1,6 +1,5 @@
 {
   "sdk": {
-    "version": "10.0.100",
     "rollForward": "latestFeature",
     "allowPrerelease": false
   }


### PR DESCRIPTION
## Summary
- Enforce NuGet FeedId on queries, indexing, and search; add ConfigurableMirrorPolicyService wired from Search/Npm/Oci options.
- Implement npm /-/v1/search with origin filtering, browse UI policy, and upstream packument/tarball pull-through.
- Add OCI manifest/blob pull-through from configured upstream registries; fix catalog discovery to filter mirrored tags in memory.
- Add cross-feed isolation and routing tests; document unified host, Ingress hostnames, and npm/OCI mirror config.

## Test plan
- [x] dotnet test tests/AvantiPoint.Packages.Integration.Tests -c Release (65 passed)
- [x] dotnet test tests/AvantiPoint.Packages.Registry.Oci.Tests -c Release (15 passed, 1 skipped)
- [x] dotnet test tests/AvantiPoint.Packages.Registry.Npm.Tests -c Release (8 passed)

Closes #560
Closes #562