### PR TITLE
Adds Azure Blob Storage connection string name support

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -41,17 +41,35 @@ jobs:
     uses: avantipoint/workflow-templates/.github/workflows/deploy-nuget.yml@master
     needs: build
     if: ${{ github.event_name == 'push' }}
+    permissions:
+      id-token: write
+      contents: read
     with:
       name: Deploy Internal
+      code-sign: true
+      codeSignEndpoint: ${{ vars.CODESIGN_ENDPOINT }}
+      codeSignAccountName: ${{ vars.CODESIGN_ACCOUNTNAME }}
+      codeSignCertificateProfile: ${{ vars.CODESIGN_CERTIFICATEPROFILE }}
     secrets:
       feedUrl: ${{ secrets.IN_HOUSE_NUGET_FEED }}
       apiKey: ${{ secrets.IN_HOUSE_API_KEY }}
+      codeSignClientId: ${{ secrets.CodeSignClientId }}
+      codeSignTenantId: ${{ secrets.CodeSignTenantId }}
 
   # deploy-public:
   #   uses: avantipoint/workflow-templates/.github/workflows/deploy-nuget.yml@master
   #   needs: build
   #   if: ${{ github.event_name == 'push' }}
+  #   permissions:
+  #     id-token: write
+  #     contents: read
   #   with:
   #     name: Deploy Public
+  #     code-sign: true
+  #     codeSignEndpoint: ${{ vars.CODESIGN_ENDPOINT }}
+  #     codeSignAccountName: ${{ vars.CODESIGN_ACCOUNTNAME }}
+  #     codeSignCertificateProfile: ${{ vars.CODESIGN_CERTIFICATEPROFILE }}
   #   secrets:
   #     apiKey: ${{ secrets.NUGET_API_KEY }}
+  #     codeSignClientId: ${{ secrets.CodeSignClientId }}
+  #     codeSignTenantId: ${{ secrets.CodeSignTenantId }}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,14 +5,14 @@
     <PackageVersion Include="Aspire.Hosting.Azure.Storage" Version="13.4.6" />
     <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.4.6" />
     <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.4.6" />
-    <PackageVersion Include="AWSSDK.KeyManagementService" Version="4.0.12.9" />
-    <PackageVersion Include="AWSSDK.S3" Version="4.0.25.3" />
-    <PackageVersion Include="AWSSDK.SecurityToken" Version="4.0.7.8" />
-    <PackageVersion Include="AWSSDK.Signer" Version="4.0.4.11" />
+    <PackageVersion Include="AWSSDK.KeyManagementService" Version="4.0.100" />
+    <PackageVersion Include="AWSSDK.S3" Version="4.0.100" />
+    <PackageVersion Include="AWSSDK.SecurityToken" Version="4.0.100" />
+    <PackageVersion Include="AWSSDK.Signer" Version="4.0.100" />
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />
     <PackageVersion Include="Azure.Security.KeyVault.Certificates" Version="4.9.0" />
     <PackageVersion Include="Azure.Search.Documents" Version="12.0.0" />
-    <PackageVersion Include="Azure.Storage.Blobs" Version="12.29.0" />
+    <PackageVersion Include="Azure.Storage.Blobs" Version="12.29.1" />
     <PackageVersion Include="OpenSearch.Client" Version="1.8.0" />
     <PackageVersion Include="OpenSearch.Net.Auth.AwsSigV4" Version="1.8.0" />
     <PackageVersion Include="CommunityToolkit.Aspire.Hosting.Minio" Version="13.4.0" />
@@ -22,7 +22,7 @@
     <PackageVersion Include="FluentFTP" Version="54.2.0" />
     <PackageVersion Include="Markdig" Version="1.3.2" />
     <PackageVersion Include="Humanizer" Version="3.0.10" />
-    <PackageVersion Include="Meziantou.Extensions.Logging.Xunit.v3" Version="2.0.2" />
+    <PackageVersion Include="Meziantou.Extensions.Logging.Xunit.v3" Version="2.0.3" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="10.0.9" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />
@@ -60,12 +60,12 @@
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.12.0" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
     <PackageVersion Include="MySql.EntityFrameworkCore" Version="10.0.7" />
-    <PackageVersion Include="MySqlConnector" Version="2.6.0" />
+    <PackageVersion Include="MySqlConnector" Version="2.6.1" />
     <PackageVersion Include="System.Formats.Asn1" Version="10.0.9" />
     <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="10.0.9" />
     <PackageVersion Include="System.Text.Json" Version="10.0.9" />
     <PackageVersion Include="System.Reflection.Metadata" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.1" />
+    <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.2" />
     <PackageVersion Include="Handlebars.Net" Version="2.1.6" />
     <PackageVersion Include="Cronos" Version="0.13.0" />
     <PackageVersion Include="MailKit" Version="4.17.0" />
@@ -74,7 +74,7 @@
     <PackageVersion Include="Microsoft.Graph" Version="6.2.0" />
     <PackageVersion Include="Postmark" Version="5.3.0" />
     <PackageVersion Include="SendGrid" Version="9.29.3" />
-    <PackageVersion Include="AWSSDK.SimpleEmailV2" Version="4.0.14.9" />
+    <PackageVersion Include="AWSSDK.SimpleEmailV2" Version="4.0.100" />
     <PackageVersion Include="Azure.Communication.Email" Version="1.1.0" />
   </ItemGroup>
   <ItemGroup>
@@ -82,8 +82,8 @@
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.7.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.16.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
   </ItemGroup>
   <ItemGroup>

--- a/src/AvantiPoint.Packages.AppHost/AvantiPoint.Packages.AppHost.csproj
+++ b/src/AvantiPoint.Packages.AppHost/AvantiPoint.Packages.AppHost.csproj
@@ -1,6 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
-  <Sdk Name="Aspire.AppHost.Sdk" Version="13.3.5" />
+﻿<Project Sdk="Aspire.AppHost.Sdk/13.3.6">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/AvantiPoint.Packages.AppHost/AvantiPoint.Packages.AppHost.csproj
+++ b/src/AvantiPoint.Packages.AppHost/AvantiPoint.Packages.AppHost.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Aspire.AppHost.Sdk/13.3.6">
+﻿<Project Sdk="Aspire.AppHost.Sdk/13.4.6">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/AvantiPoint.Packages.Azure/AzureApplicationExtensions.cs
+++ b/src/AvantiPoint.Packages.Azure/AzureApplicationExtensions.cs
@@ -34,11 +34,9 @@ namespace AvantiPoint.Packages
                 {
                     var configuration = provider.GetRequiredService<IConfiguration>();
                     var connectionString = configuration.GetConnectionString(options.ConnectionStringName);
-                    if (string.IsNullOrEmpty(connectionString))
-                    {
-                        throw new InvalidOperationException($"Connection string '{options.ConnectionStringName}' not found in configuration.");
-                    }
-                    return new BlobServiceClient(connectionString);
+                    return string.IsNullOrEmpty(connectionString)
+                        ? throw new InvalidOperationException($"Connection string '{options.ConnectionStringName}' not found in configuration.")
+                        : new BlobServiceClient(connectionString);
                 }
 
                 if (!string.IsNullOrEmpty(options.ConnectionString))
@@ -136,6 +134,15 @@ namespace AvantiPoint.Packages
             options.Services.AddSingleton(provider =>
             {
                 var options = provider.GetRequiredService<IOptions<AzureBlobStorageOptions>>().Value;
+
+                if (!string.IsNullOrEmpty(options.ConnectionStringName))
+                {
+                    var configuration = provider.GetRequiredService<IConfiguration>();
+                    var connectionString = configuration.GetConnectionString(options.ConnectionStringName);
+                    return string.IsNullOrEmpty(connectionString)
+                        ? throw new InvalidOperationException($"Connection string '{options.ConnectionStringName}' not found in configuration.")
+                        : new BlobServiceClient(connectionString);
+                }
 
                 if (!string.IsNullOrEmpty(options.ConnectionString))
                 {

--- a/src/AvantiPoint.Packages.Azure/AzureApplicationExtensions.cs
+++ b/src/AvantiPoint.Packages.Azure/AzureApplicationExtensions.cs
@@ -3,17 +3,15 @@ using AvantiPoint.Packages.Azure;
 using AvantiPoint.Packages.Azure.Storage;
 using AvantiPoint.Packages.Core;
 using AvantiPoint.Packages.Core.Discovery;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
+using BlobServiceClient = global::Azure.Storage.Blobs.BlobServiceClient;
+using StorageSharedKeyCredential = global::Azure.Storage.StorageSharedKeyCredential;
 
 namespace AvantiPoint.Packages
 {
-    //using CloudStorageAccount = Microsoft.WindowsAzure.Storage.CloudStorageAccount;
-    //using StorageCredentials = Microsoft.WindowsAzure.Storage.Auth.StorageCredentials;
-    using BlobServiceClient = global::Azure.Storage.Blobs.BlobServiceClient;
-    using StorageSharedKeyCredential = global::Azure.Storage.StorageSharedKeyCredential;
-
     /// <summary>
     /// Extension methods for adding Azure Blob Storage support.
     /// Supports both auto-discovery (configuration-based) and explicit registration modes.
@@ -32,6 +30,16 @@ namespace AvantiPoint.Packages
             options.Services.AddSingleton(provider =>
             {
                 var options = provider.GetRequiredService<IOptions<AzureBlobStorageOptions>>().Value;
+                if (!string.IsNullOrEmpty(options.ConnectionStringName))
+                {
+                    var configuration = provider.GetRequiredService<IConfiguration>();
+                    var connectionString = configuration.GetConnectionString(options.ConnectionStringName);
+                    if (string.IsNullOrEmpty(connectionString))
+                    {
+                        throw new InvalidOperationException($"Connection string '{options.ConnectionStringName}' not found in configuration.");
+                    }
+                    return new BlobServiceClient(connectionString);
+                }
 
                 if (!string.IsNullOrEmpty(options.ConnectionString))
                 {

--- a/src/AvantiPoint.Packages.Azure/Configuration/AzureBlobStorageOptions.cs
+++ b/src/AvantiPoint.Packages.Azure/Configuration/AzureBlobStorageOptions.cs
@@ -5,7 +5,7 @@ namespace AvantiPoint.Packages.Azure
 {
     /// <summary>
     /// AvantiPoint Packages's configurations to use Azure Blob Storage to store packages.
-    /// See: https://loic-sharma.github.io/BaGet/quickstart/azure/#azure-blob-storage
+    /// See: https://avantipoint.github.io/avantipoint.packages/docs/storage/azureblob
     /// </summary>
     public class AzureBlobStorageOptions : IValidatableObject
     {
@@ -33,13 +33,13 @@ namespace AvantiPoint.Packages.Azure
         /// <summary>
         /// The Azure Blob Storage container name.
         /// </summary>
-        public string Container { get; set; }
+        public string Container { get; set; } = "packages";
 
         public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {
-            const string helpUrl = "https://loic-sharma.github.io/BaGet/quickstart/azure/#azure-blob-storage";
+            const string helpUrl = "https://avantipoint.github.io/avantipoint.packages/docs/storage/azureblob";
 
-            if (string.IsNullOrEmpty(ConnectionString))
+            if (string.IsNullOrEmpty(ConnectionString) && string.IsNullOrEmpty(ConnectionStringName))
             {
                 if (string.IsNullOrEmpty(AccountName))
                 {


### PR DESCRIPTION
This PR introduces the ability to configure Azure Blob Storage using a connection string name from the application's configuration, offering greater flexibility and security by retrieving connection strings dynamically.

Key changes:
- **Azure Blob Storage Configuration:**
  - Adds a `ConnectionStringName` property to allow fetching the Azure Storage connection string from `IConfiguration`.
  - Updates validation to accept either a direct connection string or a connection string name.
  - Sets a default container name to "packages".
  - Updates internal documentation references for Azure Blob Storage.
- **Dependency Updates:**
  - Upgrades several AWS SDK packages (KMS, S3, SecurityToken, Signer, SimpleEmailV2) to version `4.0.100`.
  - Updates `Azure.Storage.Blobs`, `Meziantou.Extensions.Logging.Xunit.v3`, `MySqlConnector`, `Microsoft.Data.SqlClient`, `OpenTelemetry.Instrumentation.AspNetCore`, and `OpenTelemetry.Instrumentation.Http` to their latest versions.
  - Updates the `Aspire.AppHost.Sdk` to `13.3.6`.