### PR TITLE
Enables embedded PDBs for improved debugging

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,10 +8,17 @@
     <PackageProjectUrl>https://github.com/AvantiPoint/avantipoint.packages</PackageProjectUrl>
     <PackageOutputPath>$([System.IO.Path]::Combine('$(MSBuildThisFileDirectory)', 'Artifacts'))</PackageOutputPath>
     <IsPackable>false</IsPackable>
-    <IncludeSymbols>True</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <IncludeSource>True</IncludeSource>
     <LangVersion>latest</LangVersion>
+
+    <!-- Reproducible, debuggable packages: embed the PDB (and its Source Link + compiler
+         flags) directly in the assembly so symbols travel with the package. This makes
+         NuGet Package Explorer report Source Link, Deterministic, and Compiler Flags, and
+         lets consumers step into source without a symbol server. -->
+    <DebugType>embedded</DebugType>
+    <Deterministic>true</Deterministic>
+    <IncludeSymbols>false</IncludeSymbols>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/AvantiPoint/avantipoint.packages.git</RepositoryUrl>
     <NeutralLanguage>en</NeutralLanguage>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,10 +6,10 @@
     <PackageVersion Include="Aspire.Hosting.Azure.Storage" Version="13.4.6" />
     <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.4.6" />
     <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.4.6" />
-    <PackageVersion Include="AWSSDK.KeyManagementService" Version="4.0.100" />
-    <PackageVersion Include="AWSSDK.S3" Version="4.0.100" />
-    <PackageVersion Include="AWSSDK.SecurityToken" Version="4.0.100" />
-    <PackageVersion Include="AWSSDK.Signer" Version="4.0.100" />
+    <PackageVersion Include="AWSSDK.KeyManagementService" Version="4.0.100.1" />
+    <PackageVersion Include="AWSSDK.S3" Version="4.0.100.1" />
+    <PackageVersion Include="AWSSDK.SecurityToken" Version="4.0.100.1" />
+    <PackageVersion Include="AWSSDK.Signer" Version="4.0.100.1" />
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />
     <PackageVersion Include="Azure.Security.KeyVault.Certificates" Version="4.9.0" />
     <PackageVersion Include="Azure.Search.Documents" Version="12.0.0" />
@@ -75,7 +75,7 @@
     <PackageVersion Include="Microsoft.Graph" Version="6.2.0" />
     <PackageVersion Include="Postmark" Version="5.3.0" />
     <PackageVersion Include="SendGrid" Version="9.29.3" />
-    <PackageVersion Include="AWSSDK.SimpleEmailV2" Version="4.0.100" />
+    <PackageVersion Include="AWSSDK.SimpleEmailV2" Version="4.0.100.1" />
     <PackageVersion Include="Azure.Communication.Email" Version="1.1.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Configures projects to embed PDBs directly into assemblies. This enhancement improves the debugging experience for package consumers by making Source Link and compiler flags available without a symbol server, allowing for direct stepping into source code.

Updates minor versions for several AWSSDK packages.