### PR TITLE
feat: authenticated and multi-registry npm upstream mirrors

### DIFF
--- a/docs/docs/feeds/npm-registry.md
+++ b/docs/docs/feeds/npm-registry.md
@@ -43,6 +43,42 @@ Register `UseAvantiPointFeedPlatform()` **before** `UseRouting()` so OCI path re
 
 `MaxPublishBodyBytes` and `MaxTarballBytes` default to 100 MB and reject oversized publishes with HTTP 413.
 
+## Upstream registries (authenticated / multiple)
+
+`Mirror:RegistryUrl` configures a single unauthenticated upstream. For **authenticated upstreams** (for example FontAwesome Pro or Telerik npm) or **multiple upstreams with fallback**, use `Mirror:Registries` instead — registries are tried in ascending `Priority` order and the first hit wins:
+
+```json
+{
+  "Feed": {
+    "Npm": {
+      "Mirror": {
+        "Registries": [
+          {
+            "Url": "https://npm.fontawesome.com",
+            "Token": "your-fontawesome-pro-token",
+            "Priority": 0
+          },
+          {
+            "Url": "https://registry.npmjs.org",
+            "Priority": 10
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+Per registry:
+
+- `Token` — sent as `Authorization: Bearer <token>` (equivalent to npm's `//host/:_authToken`). Takes precedence over basic credentials.
+- `Username` / `Password` — sent as basic authentication when no `Token` is set.
+- `Priority` — lower values are tried first.
+
+Tarball downloads automatically reuse the credentials of the registry whose host matches the tarball URL, so authenticated tarball CDNs on the same host work without extra configuration. When `Registries` is non-empty, `RegistryUrl` is ignored.
+
+This lets teams consume commercial scoped packages through the internal feed without configuring per-project `.npmrc` credentials — only the feed needs the upstream token.
+
 ## Client usage
 
 ```bash

--- a/src/AvantiPoint.Feed.Platform/Configuration/NpmMirrorOptions.cs
+++ b/src/AvantiPoint.Feed.Platform/Configuration/NpmMirrorOptions.cs
@@ -4,7 +4,42 @@ namespace AvantiPoint.Feed.Platform.Configuration;
 
 public class NpmMirrorOptions
 {
+    /// <summary>
+    /// Single upstream registry shorthand (unauthenticated). Ignored when
+    /// <see cref="Registries"/> has entries.
+    /// </summary>
     public string RegistryUrl { get; set; } = "https://registry.npmjs.org";
 
+    /// <summary>
+    /// Upstream registries tried in ascending <see cref="NpmUpstreamRegistryOptions.Priority"/>
+    /// order, with optional per-registry credentials. When empty, falls back to
+    /// <see cref="RegistryUrl"/>.
+    /// </summary>
+    public List<NpmUpstreamRegistryOptions> Registries { get; set; } = [];
+
     public MirrorCachingStrategy CachingStrategy { get; set; } = MirrorCachingStrategy.IndexAndCache;
+
+    /// <summary>
+    /// The effective upstream registries: <see cref="Registries"/> ordered by priority,
+    /// or a single unauthenticated registry built from <see cref="RegistryUrl"/>.
+    /// </summary>
+    public IReadOnlyList<NpmUpstreamRegistryOptions> GetUpstreamRegistries()
+    {
+        var configured = Registries
+            .Where(static r => !string.IsNullOrWhiteSpace(r.Url))
+            .OrderBy(static r => r.Priority)
+            .ToList();
+
+        if (configured.Count > 0)
+        {
+            return configured;
+        }
+
+        if (string.IsNullOrWhiteSpace(RegistryUrl))
+        {
+            return [];
+        }
+
+        return [new NpmUpstreamRegistryOptions { Url = RegistryUrl }];
+    }
 }

--- a/src/AvantiPoint.Feed.Platform/Configuration/NpmUpstreamRegistryOptions.cs
+++ b/src/AvantiPoint.Feed.Platform/Configuration/NpmUpstreamRegistryOptions.cs
@@ -1,0 +1,24 @@
+namespace AvantiPoint.Feed.Platform.Configuration;
+
+/// <summary>
+/// An upstream npm registry used for pull-through mirroring. Supports authenticated
+/// registries (for example FontAwesome Pro or Telerik npm) via a bearer token
+/// (npm's <c>_authToken</c>) or basic credentials.
+/// </summary>
+public class NpmUpstreamRegistryOptions
+{
+    public string Url { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Bearer token sent as <c>Authorization: Bearer {Token}</c> (equivalent to npm's
+    /// <c>//registry/:_authToken</c>). Takes precedence over <see cref="Username"/>/<see cref="Password"/>.
+    /// </summary>
+    public string? Token { get; set; }
+
+    public string? Username { get; set; }
+
+    public string? Password { get; set; }
+
+    /// <summary>Registries are tried in ascending priority order; the first hit wins.</summary>
+    public int Priority { get; set; }
+}

--- a/src/AvantiPoint.Packages.Registry.Npm/NpmMirrorService.cs
+++ b/src/AvantiPoint.Packages.Registry.Npm/NpmMirrorService.cs
@@ -1,5 +1,5 @@
-using System.Net.Http.Json;
-using System.Text.Json;
+using System.Net.Http.Headers;
+using System.Text;
 using System.Text.Json.Nodes;
 using AvantiPoint.Feed.Platform;
 using AvantiPoint.Feed.Platform.Configuration;
@@ -23,8 +23,7 @@ public interface INpmMirrorService
 
 public sealed class NpmMirrorService : INpmMirrorService
 {
-    private readonly NpmFeedOptions _options;
-    private readonly IMirrorPolicyService _policy;
+    private readonly IReadOnlyList<NpmUpstreamRegistryOptions> _registries;
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly ILogger<NpmMirrorService> _logger;
 
@@ -34,11 +33,10 @@ public sealed class NpmMirrorService : INpmMirrorService
         IHttpClientFactory httpClientFactory,
         ILogger<NpmMirrorService> logger)
     {
-        _options = options.Value;
-        _policy = policy;
+        _registries = options.Value.Mirror?.GetUpstreamRegistries() ?? [];
         _httpClientFactory = httpClientFactory;
         _logger = logger;
-        Strategy = _policy.GetStrategy(FeedProtocol.Npm);
+        Strategy = policy.GetStrategy(FeedProtocol.Npm);
         MirrorOrigin = Strategy == MirrorCachingStrategy.IndexAndCache
             ? PackageOrigin.Mirrored
             : PackageOrigin.Cached;
@@ -50,23 +48,48 @@ public sealed class NpmMirrorService : INpmMirrorService
 
     public async Task<JsonObject?> FetchPackumentAsync(string packageName, CancellationToken cancellationToken = default)
     {
-        var upstreamUrl = BuildUpstreamPackumentUrl(packageName);
-        if (upstreamUrl is null)
+        foreach (var registry in _registries)
         {
-            return null;
+            var upstreamUrl = BuildUpstreamPackumentUrl(registry, packageName);
+            if (upstreamUrl is null)
+            {
+                continue;
+            }
+
+            try
+            {
+                using var client = _httpClientFactory.CreateClient(nameof(NpmMirrorService));
+                using var request = new HttpRequestMessage(HttpMethod.Get, upstreamUrl);
+                ApplyAuthentication(request, registry);
+
+                using var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                if (!response.IsSuccessStatusCode)
+                {
+                    _logger.LogDebug(
+                        "Upstream npm registry {Registry} returned {StatusCode} for {Package}",
+                        registry.Url,
+                        (int)response.StatusCode,
+                        packageName);
+                    continue;
+                }
+
+                await using var content = await response.Content.ReadAsStreamAsync(cancellationToken);
+                if (JsonNode.Parse(content) is JsonObject packument)
+                {
+                    return packument;
+                }
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.LogWarning(
+                    ex,
+                    "Failed to fetch npm packument {Package} from upstream {Registry}",
+                    packageName,
+                    registry.Url);
+            }
         }
 
-        try
-        {
-            using var client = _httpClientFactory.CreateClient(nameof(NpmMirrorService));
-            var packument = await client.GetFromJsonAsync<JsonObject>(upstreamUrl, cancellationToken);
-            return packument;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Failed to fetch npm packument {Package} from upstream", packageName);
-            return null;
-        }
+        return null;
     }
 
     public async Task<Stream?> FetchTarballAsync(string tarballUrl, CancellationToken cancellationToken = default)
@@ -74,25 +97,72 @@ public sealed class NpmMirrorService : INpmMirrorService
         try
         {
             using var client = _httpClientFactory.CreateClient(nameof(NpmMirrorService));
-            var response = await client.GetAsync(tarballUrl, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+            using var request = new HttpRequestMessage(HttpMethod.Get, tarballUrl);
+
+            // Tarball URLs come from the upstream packument and are absolute; attach the
+            // credentials of the registry that serves this host (if one is configured).
+            var registry = FindRegistryForUrl(tarballUrl);
+            if (registry is not null)
+            {
+                ApplyAuthentication(request, registry);
+            }
+
+            var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
             if (!response.IsSuccessStatusCode)
             {
+                response.Dispose();
                 return null;
             }
 
             var bytes = await response.Content.ReadAsByteArrayAsync(cancellationToken);
+            response.Dispose();
             return new MemoryStream(bytes);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             _logger.LogWarning(ex, "Failed to fetch npm tarball from {Url}", tarballUrl);
             return null;
         }
     }
 
-    private string? BuildUpstreamPackumentUrl(string normalizedName)
+    private NpmUpstreamRegistryOptions? FindRegistryForUrl(string url)
     {
-        var baseUrl = _options.Mirror?.RegistryUrl?.TrimEnd('/');
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
+        {
+            return null;
+        }
+
+        foreach (var registry in _registries)
+        {
+            if (Uri.TryCreate(registry.Url, UriKind.Absolute, out var registryUri)
+                && string.Equals(registryUri.Host, uri.Host, StringComparison.OrdinalIgnoreCase))
+            {
+                return registry;
+            }
+        }
+
+        return null;
+    }
+
+    private static void ApplyAuthentication(HttpRequestMessage request, NpmUpstreamRegistryOptions registry)
+    {
+        if (!string.IsNullOrWhiteSpace(registry.Token))
+        {
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", registry.Token);
+            return;
+        }
+
+        if (!string.IsNullOrWhiteSpace(registry.Username))
+        {
+            var credentials = Convert.ToBase64String(
+                Encoding.UTF8.GetBytes($"{registry.Username}:{registry.Password}"));
+            request.Headers.Authorization = new AuthenticationHeaderValue("Basic", credentials);
+        }
+    }
+
+    private static string? BuildUpstreamPackumentUrl(NpmUpstreamRegistryOptions registry, string normalizedName)
+    {
+        var baseUrl = registry.Url?.TrimEnd('/');
         if (string.IsNullOrEmpty(baseUrl))
         {
             return null;

--- a/src/AvantiPoint.Packages.Registry.Npm/NpmMirrorService.cs
+++ b/src/AvantiPoint.Packages.Registry.Npm/NpmMirrorService.cs
@@ -79,8 +79,15 @@ public sealed class NpmMirrorService : INpmMirrorService
                     return packument;
                 }
             }
-            catch (Exception ex) when (ex is not OperationCanceledException)
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                // Includes HttpClient timeouts (surfaced as OperationCanceledException even when
+                // the caller's token is not canceled) — treat those as an upstream failure and
+                // fall through to the next registry.
                 _logger.LogWarning(
                     ex,
                     "Failed to fetch npm packument {Package} from upstream {Registry}",
@@ -118,7 +125,11 @@ public sealed class NpmMirrorService : INpmMirrorService
             response.Dispose();
             return new MemoryStream(bytes);
         }
-        catch (Exception ex) when (ex is not OperationCanceledException)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
         {
             _logger.LogWarning(ex, "Failed to fetch npm tarball from {Url}", tarballUrl);
             return null;
@@ -132,16 +143,35 @@ public sealed class NpmMirrorService : INpmMirrorService
             return null;
         }
 
+        // Prefer the registry whose full URL (origin + path) is the longest prefix of the
+        // target URL — registries can share a host with different paths and credentials
+        // (for example multiple Azure Artifacts feeds under pkgs.dev.azure.com).
+        NpmUpstreamRegistryOptions? bestPrefixMatch = null;
+        var bestPrefixLength = -1;
+        NpmUpstreamRegistryOptions? hostMatch = null;
+
         foreach (var registry in _registries)
         {
-            if (Uri.TryCreate(registry.Url, UriKind.Absolute, out var registryUri)
-                && string.Equals(registryUri.Host, uri.Host, StringComparison.OrdinalIgnoreCase))
+            if (!Uri.TryCreate(registry.Url, UriKind.Absolute, out var registryUri)
+                || !string.Equals(registryUri.Host, uri.Host, StringComparison.OrdinalIgnoreCase))
             {
-                return registry;
+                continue;
+            }
+
+            hostMatch ??= registry;
+
+            var prefix = registryUri.GetLeftPart(UriPartial.Path).TrimEnd('/') + "/";
+            if (url.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
+                && prefix.Length > bestPrefixLength)
+            {
+                bestPrefixMatch = registry;
+                bestPrefixLength = prefix.Length;
             }
         }
 
-        return null;
+        // Fall back to a host-only match: tarball URLs are not always under the registry
+        // path (some registries serve tarballs from a different path on the same host).
+        return bestPrefixMatch ?? hostMatch;
     }
 
     private static void ApplyAuthentication(HttpRequestMessage request, NpmUpstreamRegistryOptions registry)

--- a/tests/AvantiPoint.Packages.Registry.Npm.Tests/NpmMirrorServiceTests.cs
+++ b/tests/AvantiPoint.Packages.Registry.Npm.Tests/NpmMirrorServiceTests.cs
@@ -139,6 +139,92 @@ public sealed class NpmMirrorServiceTests
         Assert.Null(authorizations["registry.npmjs.org"]);
     }
 
+    [Fact]
+    public async Task FetchTarballAsync_SelectsRegistryByLongestPathPrefix_WhenHostsCollide()
+    {
+        var authorizations = new List<string?>();
+        var handler = new CaptureRequestHandler(request =>
+        {
+            authorizations.Add(request.Headers.Authorization?.Parameter);
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent([1, 2, 3]),
+            };
+        });
+
+        var service = CreateService(handler, registries:
+        [
+            new NpmUpstreamRegistryOptions
+            {
+                Url = "https://pkgs.dev.azure.com/org/feed-a/_packaging/a/npm/registry",
+                Token = "token-a",
+                Priority = 0,
+            },
+            new NpmUpstreamRegistryOptions
+            {
+                Url = "https://pkgs.dev.azure.com/org/feed-b/_packaging/b/npm/registry",
+                Token = "token-b",
+                Priority = 10,
+            },
+        ]);
+
+        await using var tarball = await service.FetchTarballAsync(
+            "https://pkgs.dev.azure.com/org/feed-b/_packaging/b/npm/registry/left-pad/-/left-pad-1.3.0.tgz",
+            TestContext.Current.CancellationToken);
+
+        Assert.NotNull(tarball);
+        Assert.Equal(["token-b"], authorizations);
+    }
+
+    [Fact]
+    public async Task FetchPackumentAsync_FallsBack_WhenUpstreamTimesOut()
+    {
+        var requestedHosts = new List<string>();
+        var handler = new CaptureRequestHandler(request =>
+        {
+            requestedHosts.Add(request.RequestUri!.Host);
+            if (request.RequestUri.Host == "slow.example.com")
+            {
+                // HttpClient surfaces its own timeout as a cancellation even though the
+                // caller's token is not canceled.
+                throw new TaskCanceledException("The request was canceled due to the configured HttpClient.Timeout.");
+            }
+
+            return JsonResponse("""{"name":"left-pad"}""");
+        });
+
+        var service = CreateService(handler, registries:
+        [
+            new NpmUpstreamRegistryOptions { Url = "https://slow.example.com", Priority = 0 },
+            new NpmUpstreamRegistryOptions { Url = "https://fallback.example.com", Priority = 10 },
+        ]);
+
+        var packument = await service.FetchPackumentAsync("left-pad", TestContext.Current.CancellationToken);
+
+        Assert.NotNull(packument);
+        Assert.Equal(["slow.example.com", "fallback.example.com"], requestedHosts);
+    }
+
+    [Fact]
+    public async Task FetchPackumentAsync_Throws_WhenCallerCancels()
+    {
+        using var cts = new CancellationTokenSource();
+        var handler = new CaptureRequestHandler(_ =>
+        {
+            cts.Cancel();
+            throw new TaskCanceledException("canceled");
+        });
+
+        var service = CreateService(handler, registries:
+        [
+            new NpmUpstreamRegistryOptions { Url = "https://primary.example.com", Priority = 0 },
+            new NpmUpstreamRegistryOptions { Url = "https://fallback.example.com", Priority = 10 },
+        ]);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => service.FetchPackumentAsync("left-pad", cts.Token));
+    }
+
     private static NpmMirrorService CreateService(
         HttpMessageHandler handler,
         IEnumerable<NpmUpstreamRegistryOptions>? registries = null,

--- a/tests/AvantiPoint.Packages.Registry.Npm.Tests/NpmMirrorServiceTests.cs
+++ b/tests/AvantiPoint.Packages.Registry.Npm.Tests/NpmMirrorServiceTests.cs
@@ -1,0 +1,194 @@
+using System.Net;
+using System.Text;
+using AvantiPoint.Feed.Platform;
+using AvantiPoint.Feed.Platform.Configuration;
+using AvantiPoint.Feed.Platform.Mirror;
+using AvantiPoint.Packages.Core;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace AvantiPoint.Packages.Registry.Npm.Tests;
+
+public sealed class NpmMirrorServiceTests
+{
+    [Fact]
+    public async Task FetchPackumentAsync_SendsBearerToken_ForConfiguredRegistry()
+    {
+        HttpRequestMessage? captured = null;
+        var handler = new CaptureRequestHandler(request =>
+        {
+            captured = request;
+            return JsonResponse("""{"name":"@fortawesome/fontawesome-pro"}""");
+        });
+
+        var service = CreateService(handler, registries:
+        [
+            new NpmUpstreamRegistryOptions { Url = "https://npm.fontawesome.com", Token = "fa-token" },
+        ]);
+
+        var packument = await service.FetchPackumentAsync(
+            "@fortawesome/fontawesome-pro",
+            TestContext.Current.CancellationToken);
+
+        Assert.NotNull(packument);
+        Assert.NotNull(captured);
+        Assert.Equal("Bearer", captured!.Headers.Authorization?.Scheme);
+        Assert.Equal("fa-token", captured.Headers.Authorization?.Parameter);
+        Assert.StartsWith("https://npm.fontawesome.com/", captured.RequestUri!.ToString());
+    }
+
+    [Fact]
+    public async Task FetchPackumentAsync_SendsBasicCredentials_WhenNoToken()
+    {
+        HttpRequestMessage? captured = null;
+        var handler = new CaptureRequestHandler(request =>
+        {
+            captured = request;
+            return JsonResponse("""{"name":"left-pad"}""");
+        });
+
+        var service = CreateService(handler, registries:
+        [
+            new NpmUpstreamRegistryOptions
+            {
+                Url = "https://npm.example.com",
+                Username = "svc",
+                Password = "s3cret",
+            },
+        ]);
+
+        var packument = await service.FetchPackumentAsync("left-pad", TestContext.Current.CancellationToken);
+
+        Assert.NotNull(packument);
+        Assert.Equal("Basic", captured!.Headers.Authorization?.Scheme);
+        var expected = Convert.ToBase64String(Encoding.UTF8.GetBytes("svc:s3cret"));
+        Assert.Equal(expected, captured.Headers.Authorization?.Parameter);
+    }
+
+    [Fact]
+    public async Task FetchPackumentAsync_FallsBackToNextRegistry_InPriorityOrder()
+    {
+        var requestedHosts = new List<string>();
+        var handler = new CaptureRequestHandler(request =>
+        {
+            requestedHosts.Add(request.RequestUri!.Host);
+            return request.RequestUri.Host == "primary.example.com"
+                ? new HttpResponseMessage(HttpStatusCode.NotFound)
+                : JsonResponse("""{"name":"left-pad"}""");
+        });
+
+        var service = CreateService(handler, registries:
+        [
+            new NpmUpstreamRegistryOptions { Url = "https://fallback.example.com", Priority = 10 },
+            new NpmUpstreamRegistryOptions { Url = "https://primary.example.com", Priority = 0 },
+        ]);
+
+        var packument = await service.FetchPackumentAsync("left-pad", TestContext.Current.CancellationToken);
+
+        Assert.NotNull(packument);
+        Assert.Equal(["primary.example.com", "fallback.example.com"], requestedHosts);
+    }
+
+    [Fact]
+    public async Task FetchPackumentAsync_UsesRegistryUrl_WhenNoRegistriesConfigured()
+    {
+        HttpRequestMessage? captured = null;
+        var handler = new CaptureRequestHandler(request =>
+        {
+            captured = request;
+            return JsonResponse("""{"name":"left-pad"}""");
+        });
+
+        var service = CreateService(handler, registryUrl: "https://registry.npmjs.org");
+
+        var packument = await service.FetchPackumentAsync("left-pad", TestContext.Current.CancellationToken);
+
+        Assert.NotNull(packument);
+        Assert.Equal("registry.npmjs.org", captured!.RequestUri!.Host);
+        Assert.Null(captured.Headers.Authorization);
+    }
+
+    [Fact]
+    public async Task FetchTarballAsync_AttachesCredentials_ForMatchingHostOnly()
+    {
+        var authorizations = new Dictionary<string, string?>();
+        var handler = new CaptureRequestHandler(request =>
+        {
+            authorizations[request.RequestUri!.Host] = request.Headers.Authorization?.Parameter;
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent([1, 2, 3]),
+            };
+        });
+
+        var service = CreateService(handler, registries:
+        [
+            new NpmUpstreamRegistryOptions { Url = "https://npm.fontawesome.com", Token = "fa-token" },
+        ]);
+
+        await using var matching = await service.FetchTarballAsync(
+            "https://npm.fontawesome.com/@fortawesome/pro/-/pro-6.0.0.tgz",
+            TestContext.Current.CancellationToken);
+        await using var other = await service.FetchTarballAsync(
+            "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
+            TestContext.Current.CancellationToken);
+
+        Assert.NotNull(matching);
+        Assert.NotNull(other);
+        Assert.Equal("fa-token", authorizations["npm.fontawesome.com"]);
+        Assert.Null(authorizations["registry.npmjs.org"]);
+    }
+
+    private static NpmMirrorService CreateService(
+        HttpMessageHandler handler,
+        IEnumerable<NpmUpstreamRegistryOptions>? registries = null,
+        string? registryUrl = null)
+    {
+        var options = new NpmFeedOptions
+        {
+            Mirror = new NpmMirrorOptions
+            {
+                Registries = registries?.ToList() ?? [],
+            },
+        };
+
+        if (registryUrl is not null)
+        {
+            options.Mirror.RegistryUrl = registryUrl;
+        }
+
+        return new NpmMirrorService(
+            Options.Create(options),
+            new FixedMirrorPolicyService(),
+            new SharedHandlerHttpClientFactory(handler),
+            NullLogger<NpmMirrorService>.Instance);
+    }
+
+    private static HttpResponseMessage JsonResponse(string json) =>
+        new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json"),
+        };
+
+    private sealed class FixedMirrorPolicyService : IMirrorPolicyService
+    {
+        public MirrorCachingStrategy GetStrategy(FeedProtocol protocol, string? surfaceId = null) =>
+            MirrorCachingStrategy.IndexAndCache;
+
+        public bool IncludeInDiscovery(FeedProtocol protocol, PackageOrigin origin, string? surfaceId = null) => true;
+    }
+
+    private sealed class CaptureRequestHandler(Func<HttpRequestMessage, HttpResponseMessage> responder)
+        : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) =>
+            Task.FromResult(responder(request));
+    }
+
+    private sealed class SharedHandlerHttpClientFactory(HttpMessageHandler handler) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => new(handler, disposeHandler: false);
+    }
+}


### PR DESCRIPTION
Closes #654

## Problem

The npm pull-through mirror supported a single, **unauthenticated** upstream (`Mirror:RegistryUrl`). That blocked a core internal-feed scenario: proxying commercial authenticated registries (FontAwesome Pro, Telerik npm) so individual projects don't each need `.npmrc` credentials. NuGet and OCI mirrors already support authenticated, multi-source upstreams — npm was the odd one out.

## Changes

- **`NpmUpstreamRegistryOptions`** (new): `Url`, `Token` (npm `_authToken` → `Authorization: Bearer`), `Username`/`Password` (basic), `Priority`
- **`NpmMirrorOptions.Registries`**: prioritized upstream list; `GetUpstreamRegistries()` falls back to the existing `RegistryUrl` when empty (full back-compat)
- **`NpmMirrorService`**:
  - packument fetch iterates registries in ascending priority; first success wins, failures/non-2xx fall through to the next registry
  - tarball fetch attaches the credentials of the registry whose **host matches the tarball URL** (tarball URLs come from upstream packuments), anonymous otherwise
- **Docs**: authenticated upstream section in `docs/docs/feeds/npm-registry.md`

## Example

```json
"Npm": {
  "Mirror": {
    "Registries": [
      { "Url": "https://npm.fontawesome.com", "Token": "<fa-pro-token>", "Priority": 0 },
      { "Url": "https://registry.npmjs.org", "Priority": 10 }
    ]
  }
}
```

## Testing

- 5 new unit tests (`NpmMirrorServiceTests`): bearer token injection, basic auth, priority fallback ordering, `RegistryUrl` back-compat, host-matched tarball credentials
- Full `Registry.Npm.Tests` suite: **22/22 pass**
- Host project builds clean

## Follow-ups (tracked separately)

#655 promotion admin UI · #656 credential encryption · #657 npm/OCI outbound promotion · #658 npm/OCI upstream admin UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)