### PR TITLE
feat: admin UI for package groups, publish targets, and promotion

### DIFF
--- a/src/host/AvantiPoint.Packages.Host.Admin/Services/ISyndicationService.cs
+++ b/src/host/AvantiPoint.Packages.Host.Admin/Services/ISyndicationService.cs
@@ -2,11 +2,27 @@ using NuGet.Versioning;
 
 namespace AvantiPoint.Packages.Host.Admin.Services;
 
+/// <summary>
+/// The outcome of promoting a package group to a publish target. A package counts as
+/// pushed only when its primary package upload succeeds; a missing/failed symbols upload
+/// does not fail the package (many packages have no symbols to push).
+/// </summary>
+public sealed record SyndicationPushResult(
+    IReadOnlyList<string> PushedPackageIds,
+    IReadOnlyList<string> FailedPackageIds)
+{
+    public bool AllSucceeded => FailedPackageIds.Count == 0;
+}
+
 public interface ISyndicationService
 {
     Task SyndicatePackageAsync(string packageId, NuGetVersion version, CancellationToken cancellationToken = default);
 
     Task SyndicateSymbolsAsync(string packageId, NuGetVersion version, CancellationToken cancellationToken = default);
 
-    Task PushToSourceAsync(string groupName, string targetName, CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Pushes every member of <paramref name="groupName"/> to <paramref name="targetName"/>.
+    /// Throws <see cref="InvalidOperationException"/> if the group or target does not exist.
+    /// </summary>
+    Task<SyndicationPushResult> PushToSourceAsync(string groupName, string targetName, CancellationToken cancellationToken = default);
 }

--- a/src/host/AvantiPoint.Packages.Host.Admin/Services/SyndicationService.cs
+++ b/src/host/AvantiPoint.Packages.Host.Admin/Services/SyndicationService.cs
@@ -30,35 +30,58 @@ public sealed class SyndicationService(
         }
     }
 
-    public async Task PushToSourceAsync(string groupName, string targetName, CancellationToken cancellationToken = default)
+    public async Task<SyndicationPushResult> PushToSourceAsync(string groupName, string targetName, CancellationToken cancellationToken = default)
     {
         var group = await feedContext.HostPackageGroups
             .Include(x => x.Members)
             .FirstOrDefaultAsync(x => x.Name == groupName, cancellationToken);
+        if (group is null)
+        {
+            throw new InvalidOperationException($"Package group '{groupName}' does not exist.");
+        }
 
         var target = await feedContext.HostPublishTargets
             .FirstOrDefaultAsync(x => x.Name == targetName, cancellationToken);
-
-        if (group is null || target is null)
+        if (target is null)
         {
-            return;
+            throw new InvalidOperationException($"Publish target '{targetName}' does not exist.");
         }
+
+        var pushed = new List<string>();
+        var failed = new List<string>();
 
         foreach (var member in group.Members)
         {
-            var package = await packageContext.Packages
+            // Package.Version is a computed property (backed by OriginalVersionString /
+            // NormalizedVersionString) and cannot be translated to SQL, so the candidates are
+            // materialized first and ordered in memory - the same pattern used elsewhere in
+            // the codebase (e.g. DefaultPackageMetadataService, PackageSearchDocumentFactory).
+            var candidates = await packageContext.Packages
                 .Where(x => x.Id == member.PackageId)
-                .OrderByDescending(x => x.Version)
-                .FirstOrDefaultAsync(cancellationToken);
+                .ToListAsync(cancellationToken);
+            var package = candidates.OrderByDescending(x => x.Version).FirstOrDefault();
 
             if (package is null)
             {
+                failed.Add(member.PackageId);
                 continue;
             }
 
-            await downstreamPublishService.PushPackageAsync(package.Id, package.Version, target, cancellationToken);
-            await downstreamPublishService.PushSymbolsAsync(package.Id, package.Version, target, cancellationToken);
+            var packagePushed = await downstreamPublishService.PushPackageAsync(package.Id, package.Version, target, cancellationToken);
+            if (packagePushed)
+            {
+                // Symbols are best-effort: many packages have no snupkg, so a missing/failed
+                // symbols push does not mark the package itself as failed.
+                await downstreamPublishService.PushSymbolsAsync(package.Id, package.Version, target, cancellationToken);
+                pushed.Add(member.PackageId);
+            }
+            else
+            {
+                failed.Add(member.PackageId);
+            }
         }
+
+        return new SyndicationPushResult(pushed, failed);
     }
 
     private async Task<IReadOnlyList<HostPublishTarget>> TargetLookupAsync(string packageId, CancellationToken cancellationToken)

--- a/src/host/AvantiPoint.Packages.Host/Pages/Account/PackageGroups.cshtml
+++ b/src/host/AvantiPoint.Packages.Host/Pages/Account/PackageGroups.cshtml
@@ -1,0 +1,84 @@
+@page
+@model AvantiPoint.Packages.Host.Pages.Account.PackageGroupsModel
+@{
+    ViewData["Title"] = "Package Groups";
+}
+
+<h1>Package Groups</h1>
+<p>Group packages and promote them to configured <a asp-page="PublishTargets">publish targets</a>. Groups with syndication targets are also pushed automatically when new versions are published.</p>
+
+@if (!string.IsNullOrEmpty(Model.StatusMessage))
+{
+    <p class="status-message">@Model.StatusMessage</p>
+}
+
+<h2>Create group</h2>
+<form method="post" asp-page-handler="CreateGroup">
+    <label asp-for="NewGroupName">Group name</label>
+    <input asp-for="NewGroupName" required />
+    <button type="submit">Create</button>
+</form>
+
+@foreach (var group in Model.Groups)
+{
+    <section>
+        <h2>@group.Name</h2>
+        <form method="post" asp-page-handler="DeleteGroup" style="display:inline">
+            <input type="hidden" name="groupName" value="@group.Name" />
+            <button type="submit" onclick="return confirm('Delete this group?')">Delete group</button>
+        </form>
+
+        <h3>Members</h3>
+        <ul>
+            @foreach (var member in group.Members.OrderBy(m => m.PackageId))
+            {
+                <li>
+                    @member.PackageId
+                    <form method="post" asp-page-handler="RemoveMember" style="display:inline">
+                        <input type="hidden" name="groupName" value="@group.Name" />
+                        <input type="hidden" name="packageId" value="@member.PackageId" />
+                        <button type="submit">Remove</button>
+                    </form>
+                </li>
+            }
+        </ul>
+        <form method="post" asp-page-handler="AddMember">
+            <input type="hidden" name="groupName" value="@group.Name" />
+            <input name="packageId" placeholder="Package ID" required />
+            <button type="submit">Add package</button>
+        </form>
+
+        <h3>Syndication targets</h3>
+        <ul>
+            @foreach (var syndication in group.Syndications.OrderBy(s => s.PublishTargetName))
+            {
+                <li>
+                    @syndication.PublishTargetName
+                    <form method="post" asp-page-handler="Promote" style="display:inline">
+                        <input type="hidden" name="groupName" value="@group.Name" />
+                        <input type="hidden" name="targetName" value="@syndication.PublishTargetName" />
+                        <button type="submit">Promote now</button>
+                    </form>
+                    <form method="post" asp-page-handler="RemoveSyndication" style="display:inline">
+                        <input type="hidden" name="groupName" value="@group.Name" />
+                        <input type="hidden" name="targetName" value="@syndication.PublishTargetName" />
+                        <button type="submit">Remove</button>
+                    </form>
+                </li>
+            }
+        </ul>
+        @if (Model.Targets.Count > 0)
+        {
+            <form method="post" asp-page-handler="AddSyndication">
+                <input type="hidden" name="groupName" value="@group.Name" />
+                <select name="targetName">
+                    @foreach (var target in Model.Targets)
+                    {
+                        <option value="@target.Name">@target.Name</option>
+                    }
+                </select>
+                <button type="submit">Add target</button>
+            </form>
+        }
+    </section>
+}

--- a/src/host/AvantiPoint.Packages.Host/Pages/Account/PackageGroups.cshtml.cs
+++ b/src/host/AvantiPoint.Packages.Host/Pages/Account/PackageGroups.cshtml.cs
@@ -1,0 +1,163 @@
+using System.ComponentModel.DataAnnotations;
+using AvantiPoint.Packages.Host.Admin.Authentication;
+using AvantiPoint.Packages.Host.Admin.Data;
+using AvantiPoint.Packages.Host.Admin.Entities;
+using AvantiPoint.Packages.Host.Admin.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+
+namespace AvantiPoint.Packages.Host.Pages.Account;
+
+[Authorize(Roles = FeedRoles.Admin)]
+public class PackageGroupsModel(
+    IHostIdentityContext context,
+    ISyndicationService syndicationService,
+    ILogger<PackageGroupsModel> logger) : PageModel
+{
+    public IList<HostPackageGroup> Groups { get; private set; } = [];
+
+    public IList<HostPublishTarget> Targets { get; private set; } = [];
+
+    [BindProperty]
+    [Required]
+    [StringLength(128)]
+    public string? NewGroupName { get; set; }
+
+    [TempData]
+    public string? StatusMessage { get; set; }
+
+    public async Task OnGetAsync() => await LoadAsync();
+
+    public async Task<IActionResult> OnPostCreateGroupAsync()
+    {
+        if (string.IsNullOrWhiteSpace(NewGroupName))
+        {
+            await LoadAsync();
+            return Page();
+        }
+
+        var name = NewGroupName.Trim();
+        if (!await context.HostPackageGroups.AnyAsync(g => g.Name == name))
+        {
+            context.HostPackageGroups.Add(new HostPackageGroup { Name = name });
+            await context.SaveChangesAsync(default);
+            StatusMessage = $"Created group '{name}'.";
+        }
+
+        return RedirectToPage();
+    }
+
+    public async Task<IActionResult> OnPostDeleteGroupAsync(string groupName)
+    {
+        var group = await context.HostPackageGroups
+            .Include(g => g.Members)
+            .Include(g => g.Syndications)
+            .FirstOrDefaultAsync(g => g.Name == groupName);
+        if (group is not null)
+        {
+            context.HostPackageGroupMembers.RemoveRange(group.Members);
+            context.HostPackageGroupSyndications.RemoveRange(group.Syndications);
+            context.HostPackageGroups.Remove(group);
+            await context.SaveChangesAsync(default);
+            StatusMessage = $"Deleted group '{groupName}'.";
+        }
+
+        return RedirectToPage();
+    }
+
+    public async Task<IActionResult> OnPostAddMemberAsync(string groupName, string packageId)
+    {
+        if (!string.IsNullOrWhiteSpace(packageId))
+        {
+            packageId = packageId.Trim();
+            var exists = await context.HostPackageGroupMembers
+                .AnyAsync(m => m.PackageGroupName == groupName && m.PackageId == packageId);
+            if (!exists)
+            {
+                context.HostPackageGroupMembers.Add(new HostPackageGroupMember
+                {
+                    PackageGroupName = groupName,
+                    PackageId = packageId,
+                });
+                await context.SaveChangesAsync(default);
+                StatusMessage = $"Added '{packageId}' to '{groupName}'.";
+            }
+        }
+
+        return RedirectToPage();
+    }
+
+    public async Task<IActionResult> OnPostRemoveMemberAsync(string groupName, string packageId)
+    {
+        var member = await context.HostPackageGroupMembers
+            .FirstOrDefaultAsync(m => m.PackageGroupName == groupName && m.PackageId == packageId);
+        if (member is not null)
+        {
+            context.HostPackageGroupMembers.Remove(member);
+            await context.SaveChangesAsync(default);
+            StatusMessage = $"Removed '{packageId}' from '{groupName}'.";
+        }
+
+        return RedirectToPage();
+    }
+
+    public async Task<IActionResult> OnPostAddSyndicationAsync(string groupName, string targetName)
+    {
+        var exists = await context.HostPackageGroupSyndications
+            .AnyAsync(s => s.PackageGroupName == groupName && s.PublishTargetName == targetName);
+        if (!exists && await context.HostPublishTargets.AnyAsync(t => t.Name == targetName))
+        {
+            context.HostPackageGroupSyndications.Add(new HostPackageGroupSyndication
+            {
+                PackageGroupName = groupName,
+                PublishTargetName = targetName,
+            });
+            await context.SaveChangesAsync(default);
+            StatusMessage = $"'{groupName}' now syndicates to '{targetName}'.";
+        }
+
+        return RedirectToPage();
+    }
+
+    public async Task<IActionResult> OnPostRemoveSyndicationAsync(string groupName, string targetName)
+    {
+        var syndication = await context.HostPackageGroupSyndications
+            .FirstOrDefaultAsync(s => s.PackageGroupName == groupName && s.PublishTargetName == targetName);
+        if (syndication is not null)
+        {
+            context.HostPackageGroupSyndications.Remove(syndication);
+            await context.SaveChangesAsync(default);
+            StatusMessage = $"'{groupName}' no longer syndicates to '{targetName}'.";
+        }
+
+        return RedirectToPage();
+    }
+
+    public async Task<IActionResult> OnPostPromoteAsync(string groupName, string targetName)
+    {
+        try
+        {
+            await syndicationService.PushToSourceAsync(groupName, targetName);
+            StatusMessage = $"Promoted group '{groupName}' to '{targetName}'.";
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to promote group {Group} to {Target}", groupName, targetName);
+            StatusMessage = $"Promotion of '{groupName}' to '{targetName}' failed: {ex.Message}";
+        }
+
+        return RedirectToPage();
+    }
+
+    private async Task LoadAsync()
+    {
+        Groups = await context.HostPackageGroups
+            .Include(g => g.Members)
+            .Include(g => g.Syndications)
+            .OrderBy(g => g.Name)
+            .ToListAsync();
+        Targets = await context.HostPublishTargets.OrderBy(t => t.Name).ToListAsync();
+    }
+}

--- a/src/host/AvantiPoint.Packages.Host/Pages/Account/PackageGroups.cshtml.cs
+++ b/src/host/AvantiPoint.Packages.Host/Pages/Account/PackageGroups.cshtml.cs
@@ -139,8 +139,12 @@ public class PackageGroupsModel(
     {
         try
         {
-            await syndicationService.PushToSourceAsync(groupName, targetName);
-            StatusMessage = $"Promoted group '{groupName}' to '{targetName}'.";
+            var result = await syndicationService.PushToSourceAsync(groupName, targetName);
+            StatusMessage = result.AllSucceeded
+                ? $"Promoted group '{groupName}' to '{targetName}' ({result.PushedPackageIds.Count} package(s))."
+                : $"Promotion of '{groupName}' to '{targetName}' had failures: " +
+                  $"{result.PushedPackageIds.Count} succeeded, {result.FailedPackageIds.Count} failed " +
+                  $"({string.Join(", ", result.FailedPackageIds)}).";
         }
         catch (Exception ex)
         {

--- a/src/host/AvantiPoint.Packages.Host/Pages/Account/PublishTargets.cshtml
+++ b/src/host/AvantiPoint.Packages.Host/Pages/Account/PublishTargets.cshtml
@@ -1,0 +1,70 @@
+@page
+@model AvantiPoint.Packages.Host.Pages.Account.PublishTargetsModel
+@{
+    ViewData["Title"] = "Publish Targets";
+}
+
+<h1>Publish Targets</h1>
+<p>Downstream registries (for example NuGet.org) that package groups can be promoted to.</p>
+
+@if (!string.IsNullOrEmpty(Model.StatusMessage))
+{
+    <p class="status-message">@Model.StatusMessage</p>
+}
+
+<h2>@(string.IsNullOrEmpty(Model.EditName) ? "Add target" : $"Edit '{Model.EditName}'")</h2>
+<form method="post" asp-page-handler="Save">
+    <input type="hidden" asp-for="EditName" />
+    <div>
+        <label asp-for="Input.Name">Name</label>
+        <input asp-for="Input.Name" required readonly="@(!string.IsNullOrEmpty(Model.EditName))" />
+    </div>
+    <div>
+        <label asp-for="Input.PublishEndpoint">Publish endpoint</label>
+        <input asp-for="Input.PublishEndpoint" required placeholder="https://www.nuget.org" />
+    </div>
+    <div>
+        <label asp-for="Input.ApiToken">API token @(string.IsNullOrEmpty(Model.EditName) ? "" : "(leave blank to keep current)")</label>
+        <input asp-for="Input.ApiToken" type="password" autocomplete="off" />
+    </div>
+    <div>
+        <label asp-for="Input.Legacy">Legacy (v2) endpoint</label>
+        <input asp-for="Input.Legacy" type="checkbox" />
+    </div>
+    <button type="submit">@(string.IsNullOrEmpty(Model.EditName) ? "Add target" : "Save changes")</button>
+    @if (!string.IsNullOrEmpty(Model.EditName))
+    {
+        <a asp-page="PublishTargets">Cancel</a>
+    }
+</form>
+
+<h2>Configured targets</h2>
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Endpoint</th>
+            <th>Added by</th>
+            <th>Added</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+        @foreach (var target in Model.Targets)
+        {
+            <tr>
+                <td>@target.Name</td>
+                <td>@target.PublishEndpoint</td>
+                <td>@target.AddedBy</td>
+                <td>@target.Timestamp.ToString("yyyy-MM-dd")</td>
+                <td>
+                    <a asp-page="PublishTargets" asp-route-editName="@target.Name">Edit</a>
+                    <form method="post" asp-page-handler="Delete" style="display:inline">
+                        <input type="hidden" name="name" value="@target.Name" />
+                        <button type="submit" onclick="return confirm('Delete this target?')">Delete</button>
+                    </form>
+                </td>
+            </tr>
+        }
+    </tbody>
+</table>

--- a/src/host/AvantiPoint.Packages.Host/Pages/Account/PublishTargets.cshtml
+++ b/src/host/AvantiPoint.Packages.Host/Pages/Account/PublishTargets.cshtml
@@ -21,7 +21,8 @@
     </div>
     <div>
         <label asp-for="Input.PublishEndpoint">Publish endpoint</label>
-        <input asp-for="Input.PublishEndpoint" required placeholder="https://www.nuget.org" />
+        <input asp-for="Input.PublishEndpoint" required placeholder="https://api.nuget.org/v3/index.json" />
+        <small>Must be the v3 service index URL (ends in <code>/v3/index.json</code>) — not the NuGet.org website. For example, use <code>https://api.nuget.org/v3/index.json</code>, not <code>https://www.nuget.org</code>.</small>
     </div>
     <div>
         <label asp-for="Input.ApiToken">API token @(string.IsNullOrEmpty(Model.EditName) ? "" : "(leave blank to keep current)")</label>

--- a/src/host/AvantiPoint.Packages.Host/Pages/Account/PublishTargets.cshtml.cs
+++ b/src/host/AvantiPoint.Packages.Host/Pages/Account/PublishTargets.cshtml.cs
@@ -53,6 +53,15 @@ public class PublishTargetsModel(
             return Page();
         }
 
+        if (LooksLikeNuGetWebsiteRootInsteadOfServiceIndex(Input.PublishEndpoint))
+        {
+            ModelState.AddModelError(
+                "Input.PublishEndpoint",
+                "This looks like the NuGet.org website, not its v3 service index. Use https://api.nuget.org/v3/index.json instead.");
+            await LoadTargetsAsync();
+            return Page();
+        }
+
         if (!string.IsNullOrEmpty(EditName))
         {
             var existing = await context.HostPublishTargets.FirstOrDefaultAsync(t => t.Name == EditName);
@@ -112,6 +121,25 @@ public class PublishTargetsModel(
         }
 
         return RedirectToPage();
+    }
+
+    /// <summary>
+    /// Catches the common mistake of pointing a target at the NuGet.org website instead of
+    /// its v3 service index; <see cref="AvantiPoint.Packages.Protocol.NuGetClient"/> requires
+    /// the service index URL and fails discovery against the website root.
+    /// </summary>
+    private static bool LooksLikeNuGetWebsiteRootInsteadOfServiceIndex(string endpoint)
+    {
+        if (!Uri.TryCreate(endpoint, UriKind.Absolute, out var uri))
+        {
+            return false;
+        }
+
+        var host = uri.Host.ToLowerInvariant();
+        var isNuGetOrgHost = host is "nuget.org" or "www.nuget.org";
+        var looksLikeServiceIndex = uri.AbsolutePath.Contains("index.json", StringComparison.OrdinalIgnoreCase);
+
+        return isNuGetOrgHost && !looksLikeServiceIndex;
     }
 
     private async Task LoadTargetsAsync() =>

--- a/src/host/AvantiPoint.Packages.Host/Pages/Account/PublishTargets.cshtml.cs
+++ b/src/host/AvantiPoint.Packages.Host/Pages/Account/PublishTargets.cshtml.cs
@@ -1,0 +1,134 @@
+using System.ComponentModel.DataAnnotations;
+using AvantiPoint.Packages.Core;
+using AvantiPoint.Packages.Host.Admin.Authentication;
+using AvantiPoint.Packages.Host.Admin.Data;
+using AvantiPoint.Packages.Host.Admin.Entities;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+
+namespace AvantiPoint.Packages.Host.Pages.Account;
+
+[Authorize(Roles = FeedRoles.Admin)]
+public class PublishTargetsModel(
+    IHostIdentityContext context,
+    ISecretProtector secretProtector) : PageModel
+{
+    public IList<HostPublishTarget> Targets { get; private set; } = [];
+
+    [BindProperty]
+    public PublishTargetInput Input { get; set; } = new();
+
+    [BindProperty]
+    public string? EditName { get; set; }
+
+    [TempData]
+    public string? StatusMessage { get; set; }
+
+    public async Task OnGetAsync(string? editName)
+    {
+        EditName = editName;
+        await LoadTargetsAsync();
+        if (!string.IsNullOrEmpty(editName))
+        {
+            var target = Targets.FirstOrDefault(t => t.Name == editName);
+            if (target is not null)
+            {
+                Input = new PublishTargetInput
+                {
+                    Name = target.Name,
+                    PublishEndpoint = target.PublishEndpoint,
+                    Legacy = target.Legacy,
+                };
+            }
+        }
+    }
+
+    public async Task<IActionResult> OnPostSaveAsync()
+    {
+        if (!ModelState.IsValid)
+        {
+            await LoadTargetsAsync();
+            return Page();
+        }
+
+        if (!string.IsNullOrEmpty(EditName))
+        {
+            var existing = await context.HostPublishTargets.FirstOrDefaultAsync(t => t.Name == EditName);
+            if (existing is null)
+            {
+                StatusMessage = $"Target '{EditName}' no longer exists.";
+                return RedirectToPage();
+            }
+
+            existing.PublishEndpoint = Input.PublishEndpoint.Trim();
+            existing.Legacy = Input.Legacy;
+            if (!string.IsNullOrWhiteSpace(Input.ApiToken))
+            {
+                // Blank token keeps the existing secret.
+                existing.ApiToken = secretProtector.Protect(Input.ApiToken)!;
+            }
+
+            await context.SaveChangesAsync(default);
+            StatusMessage = $"Updated target '{existing.Name}'.";
+        }
+        else
+        {
+            if (string.IsNullOrWhiteSpace(Input.ApiToken))
+            {
+                ModelState.AddModelError("Input.ApiToken", "An API token is required for new targets.");
+                await LoadTargetsAsync();
+                return Page();
+            }
+
+            context.HostPublishTargets.Add(new HostPublishTarget
+            {
+                Name = Input.Name.Trim(),
+                PublishEndpoint = Input.PublishEndpoint.Trim(),
+                ApiToken = secretProtector.Protect(Input.ApiToken)!,
+                Legacy = Input.Legacy,
+                AddedBy = User.Identity?.Name ?? "admin",
+                Timestamp = DateTimeOffset.UtcNow,
+            });
+            await context.SaveChangesAsync(default);
+            StatusMessage = $"Added target '{Input.Name}'.";
+        }
+
+        return RedirectToPage();
+    }
+
+    public async Task<IActionResult> OnPostDeleteAsync(string name)
+    {
+        var target = await context.HostPublishTargets
+            .Include(t => t.Syndications)
+            .FirstOrDefaultAsync(t => t.Name == name);
+        if (target is not null)
+        {
+            context.HostPackageGroupSyndications.RemoveRange(target.Syndications);
+            context.HostPublishTargets.Remove(target);
+            await context.SaveChangesAsync(default);
+            StatusMessage = $"Deleted target '{name}'.";
+        }
+
+        return RedirectToPage();
+    }
+
+    private async Task LoadTargetsAsync() =>
+        Targets = await context.HostPublishTargets.OrderBy(t => t.Name).ToListAsync();
+
+    public sealed class PublishTargetInput
+    {
+        [Required]
+        [StringLength(128)]
+        public string Name { get; set; } = string.Empty;
+
+        [Required]
+        [Url]
+        public string PublishEndpoint { get; set; } = string.Empty;
+
+        public string? ApiToken { get; set; }
+
+        public bool Legacy { get; set; }
+    }
+}

--- a/src/host/AvantiPoint.Packages.Host/Pages/Shared/_Layout.cshtml
+++ b/src/host/AvantiPoint.Packages.Host/Pages/Shared/_Layout.cshtml
@@ -20,6 +20,8 @@
             <a href="/Account/ApiKeys">API Keys</a>
             <a href="/Account/Users">Users</a>
             <a href="/Account/PackageSources">Package Sources</a>
+            <a href="/Account/PackageGroups">Package Groups</a>
+            <a href="/Account/PublishTargets">Publish Targets</a>
             <a href="/Account/Settings">Settings</a>
         </nav>
     </header>

--- a/tests/AvantiPoint.Packages.Host.Admin.Tests/AvantiPoint.Packages.Host.Admin.Tests.csproj
+++ b/tests/AvantiPoint.Packages.Host.Admin.Tests/AvantiPoint.Packages.Host.Admin.Tests.csproj
@@ -22,6 +22,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\host\AvantiPoint.Packages.Host.Admin\AvantiPoint.Packages.Host.Admin.csproj" />
+    <ProjectReference Include="..\..\src\host\AvantiPoint.Packages.Host.Database.Sqlite\AvantiPoint.Packages.Host.Database.Sqlite.csproj" />
+    <ProjectReference Include="..\..\src\AvantiPoint.Packages.Database.Sqlite\AvantiPoint.Packages.Database.Sqlite.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/AvantiPoint.Packages.Host.Admin.Tests/SyndicationServiceTests.cs
+++ b/tests/AvantiPoint.Packages.Host.Admin.Tests/SyndicationServiceTests.cs
@@ -1,0 +1,178 @@
+using AvantiPoint.Packages.Core;
+using AvantiPoint.Packages.Database.Sqlite;
+using AvantiPoint.Packages.Host.Admin.Entities;
+using AvantiPoint.Packages.Host.Admin.Services;
+using AvantiPoint.Packages.Host.Database.Sqlite;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using NuGet.Versioning;
+
+namespace AvantiPoint.Packages.Host.Admin.Tests;
+
+public sealed class SyndicationServiceTests : IDisposable
+{
+    private readonly SqliteConnection _packageConnection;
+    private readonly SqliteConnection _identityConnection;
+    private readonly SqliteContext _packageContext;
+    private readonly HostSqliteContext _identityContext;
+
+    public SyndicationServiceTests()
+    {
+        _packageConnection = new SqliteConnection("DataSource=:memory:");
+        _packageConnection.Open();
+        _packageContext = new SqliteContext(new DbContextOptionsBuilder<SqliteContext>().UseSqlite(_packageConnection).Options);
+        _packageContext.Database.EnsureCreated();
+
+        _identityConnection = new SqliteConnection("DataSource=:memory:");
+        _identityConnection.Open();
+        _identityContext = new HostSqliteContext(new DbContextOptionsBuilder<HostSqliteContext>().UseSqlite(_identityConnection).Options);
+        _identityContext.Database.EnsureCreated();
+    }
+
+    [Fact]
+    public async Task PushToSourceAsync_ReportsFailures_WhenDownstreamPushFails()
+    {
+        SeedPackage("Good.Package", "1.0.0");
+        SeedPackage("Bad.Package", "2.0.0");
+        var target = await SeedGroupAndTargetAsync("mygroup", "nuget-org", "Good.Package", "Bad.Package");
+
+        var downstream = new Mock<IDownstreamPublishService>();
+        downstream
+            .Setup(d => d.PushPackageAsync("Good.Package", It.IsAny<NuGetVersion>(), It.IsAny<HostPublishTarget>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        downstream
+            .Setup(d => d.PushSymbolsAsync("Good.Package", It.IsAny<NuGetVersion>(), It.IsAny<HostPublishTarget>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false); // no symbols - must not fail the package
+        downstream
+            .Setup(d => d.PushPackageAsync("Bad.Package", It.IsAny<NuGetVersion>(), It.IsAny<HostPublishTarget>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false); // upload genuinely fails
+
+        var service = CreateService(downstream.Object);
+
+        var result = await service.PushToSourceAsync("mygroup", "nuget-org", TestContext.Current.CancellationToken);
+
+        Assert.False(result.AllSucceeded);
+        Assert.Equal(["Good.Package"], result.PushedPackageIds);
+        Assert.Equal(["Bad.Package"], result.FailedPackageIds);
+        downstream.Verify(
+            d => d.PushSymbolsAsync("Bad.Package", It.IsAny<NuGetVersion>(), It.IsAny<HostPublishTarget>(), It.IsAny<CancellationToken>()),
+            Times.Never); // symbols are never attempted after a failed package push
+    }
+
+    [Fact]
+    public async Task PushToSourceAsync_AllSucceed_ReportsSuccess()
+    {
+        SeedPackage("Good.Package", "1.0.0");
+        await SeedGroupAndTargetAsync("mygroup", "nuget-org", "Good.Package");
+
+        var downstream = new Mock<IDownstreamPublishService>();
+        downstream
+            .Setup(d => d.PushPackageAsync(It.IsAny<string>(), It.IsAny<NuGetVersion>(), It.IsAny<HostPublishTarget>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        downstream
+            .Setup(d => d.PushSymbolsAsync(It.IsAny<string>(), It.IsAny<NuGetVersion>(), It.IsAny<HostPublishTarget>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var service = CreateService(downstream.Object);
+
+        var result = await service.PushToSourceAsync("mygroup", "nuget-org", TestContext.Current.CancellationToken);
+
+        Assert.True(result.AllSucceeded);
+        Assert.Equal(["Good.Package"], result.PushedPackageIds);
+        Assert.Empty(result.FailedPackageIds);
+    }
+
+    [Fact]
+    public async Task PushToSourceAsync_MissingLocalPackage_CountsAsFailed()
+    {
+        // Member added to the group, but no matching row in the package catalog.
+        await SeedGroupAndTargetAsync("mygroup", "nuget-org", "Ghost.Package");
+
+        var downstream = new Mock<IDownstreamPublishService>(MockBehavior.Strict);
+        var service = CreateService(downstream.Object);
+
+        var result = await service.PushToSourceAsync("mygroup", "nuget-org", TestContext.Current.CancellationToken);
+
+        Assert.False(result.AllSucceeded);
+        Assert.Equal(["Ghost.Package"], result.FailedPackageIds);
+    }
+
+    [Fact]
+    public async Task PushToSourceAsync_UnknownGroup_Throws()
+    {
+        var service = CreateService(Mock.Of<IDownstreamPublishService>(MockBehavior.Strict));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => service.PushToSourceAsync("does-not-exist", "nuget-org", TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task PushToSourceAsync_UnknownTarget_Throws()
+    {
+        _identityContext.HostPackageGroups.Add(new HostPackageGroup { Name = "mygroup" });
+        await _identityContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var service = CreateService(Mock.Of<IDownstreamPublishService>(MockBehavior.Strict));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => service.PushToSourceAsync("mygroup", "does-not-exist", TestContext.Current.CancellationToken));
+    }
+
+    private SyndicationService CreateService(IDownstreamPublishService downstreamPublishService) =>
+        new(
+            _identityContext,
+            _packageContext,
+            Mock.Of<IPackageStorageService>(),
+            Mock.Of<ISymbolStorageService>(),
+            downstreamPublishService);
+
+    private void SeedPackage(string id, string version)
+    {
+        _packageContext.Packages.Add(new Package
+        {
+            Id = id,
+            Version = NuGetVersion.Parse(version),
+            Listed = true,
+            Published = DateTime.UtcNow,
+            Authors = ["test"],
+        });
+        _packageContext.SaveChanges();
+    }
+
+    private async Task<HostPublishTarget> SeedGroupAndTargetAsync(string groupName, string targetName, params string[] packageIds)
+    {
+        var target = new HostPublishTarget
+        {
+            Name = targetName,
+            PublishEndpoint = "https://api.nuget.org/v3/index.json",
+            ApiToken = "protected-token",
+            AddedBy = "test",
+            Timestamp = DateTimeOffset.UtcNow,
+        };
+        _identityContext.HostPublishTargets.Add(target);
+
+        var group = new HostPackageGroup { Name = groupName };
+        _identityContext.HostPackageGroups.Add(group);
+
+        foreach (var packageId in packageIds)
+        {
+            _identityContext.HostPackageGroupMembers.Add(new HostPackageGroupMember
+            {
+                PackageGroupName = groupName,
+                PackageId = packageId,
+            });
+        }
+
+        await _identityContext.SaveChangesAsync();
+        return target;
+    }
+
+    public void Dispose()
+    {
+        _packageContext.Dispose();
+        _packageConnection.Dispose();
+        _identityContext.Dispose();
+        _identityConnection.Dispose();
+    }
+}


### PR DESCRIPTION
Closes #655

> Supersedes #665, which GitHub auto-closed (not merged) when its original base branch `dev/ds/secret-protection` was deleted after PR #663 merged. Same commits, now targeting `master` directly since #663 (credential encryption) is already merged.
>
> **Note:** PR #667 (npm/OCI outbound promotion, addresses #657) is stacked on top of this branch (`dev/ds/protocol-promotion` → `dev/ds/promotion-ui`). Please do **not** delete the `dev/ds/promotion-ui` branch on merge — #667 still depends on it.

## Problem

The promotion/syndication backend (`HostPackageGroup`, `HostPackageGroupMember`, `HostPackageGroupSyndication`, `HostPublishTarget`, `SyndicationService`, `DownstreamPublishService`) existed **with no admin UI** — defining groups/targets required direct DB manipulation.

## Changes

**`/Account/PublishTargets`** (new) — list/create/edit/delete downstream registries; tokens encrypted via `ISecretProtector`; deleting a target removes its group mappings.

**`/Account/PackageGroups`** (new) — create/delete groups, add/remove package-ID members, map groups → publish targets, **Promote now** action invoking `ISyndicationService.PushToSourceAsync` with failures surfaced in the status message.

**Nav** — links for both pages.

## Review history (already addressed, included in these commits)

- **P2**: `PushToSourceAsync` discarded the downstream push result, so "Promote now" reported success even when a package failed to publish → `PushToSourceAsync` now returns a `SyndicationPushResult` (pushed/failed package IDs); the handler surfaces per-package outcome
  - Fixing this surfaced a **separate crash bug**: the query ordered by `Package.Version`, a computed property EF Core can't translate to SQL, so promotion threw before it could report anything for any existing group member. Fixed by materializing candidates before ordering in memory.
- **P2**: the publish-endpoint placeholder suggested the NuGet.org website root instead of its v3 service index → corrected placeholder/hint text plus a validation error when the endpoint looks like the website root

## Testing

- `SyndicationServiceTests` (Sqlite-backed): failure reporting, missing local package, unknown group/target, the version-ordering fix
- Full solution builds with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)