### PR TITLE
Add feed operations and OCI garbage collection

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -87,6 +87,8 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.16.0" />
+    <PackageVersion Include="prometheus-net" Version="8.2.1" />
+    <PackageVersion Include="prometheus-net.AspNetCore" Version="8.2.1" />
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.10.91" />

--- a/docs/docs/hosting.md
+++ b/docs/docs/hosting.md
@@ -124,6 +124,8 @@ Publish tokens are encrypted using the Data Protection key ring described above.
 
 `GET /health` runs checks against both the package catalog (`IContext`) and host identity (`IHostIdentityContext`) databases on the same connection.
 
+For Prometheus metrics, per-feed readiness, OCI garbage collection, retention scheduling, and API key rotation, see [Operations](operations.md).
+
 ### Project layout
 
 ```

--- a/docs/docs/operations.md
+++ b/docs/docs/operations.md
@@ -1,0 +1,92 @@
+---
+id: operations
+title: Operations
+sidebar_label: Operations
+---
+
+The production host exposes readiness, Prometheus metrics, scheduled OCI garbage collection, retention, and audit facilities. Keep operational endpoints on a private network or restrict them at the reverse proxy.
+
+## Prometheus metrics
+
+Prometheus metrics are available at `GET /metrics`. Feed metrics use only the bounded `feed` and `type` labels so package names, repository names, versions, and digests do not create unbounded time series.
+
+| Metric | Type | Meaning |
+|--------|------|---------|
+| `feed_push_total{feed,type}` | Counter | Completed top-level artifact uploads |
+| `feed_pull_total{feed,type}` | Counter | Completed top-level artifact downloads |
+| `blob_bytes_stored{feed,type}` | Gauge | Bytes currently held in OCI content-addressed storage |
+
+Example Prometheus configuration:
+
+```yaml
+scrape_configs:
+  - job_name: avantipoint-packages
+    metrics_path: /metrics
+    static_configs:
+      - targets: [packages.internal.example:8080]
+```
+
+The metrics endpoint is anonymous so a scraper can reach it without a feed API token. Do not expose it directly to the public internet. Apply an IP allowlist, private ingress, or an authentication policy at the reverse proxy.
+
+## Readiness and liveness
+
+The production host exposes these endpoints:
+
+| Endpoint | Purpose |
+|----------|---------|
+| `GET /health` | Host readiness, including the package catalog and host identity databases |
+| `GET /health/feeds` | Readiness and registered surfaces for the configured feed |
+| `GET /health/feeds/{feedId}` | The same report for a specific feed ID; an unknown ID returns `404` |
+
+A feed readiness response is `200` when all registered health checks are healthy and `503` otherwise. The response includes each registered NuGet, npm, and OCI surface plus the underlying health-check results. Use `/health` or `/health/feeds/{feedId}` for readiness probes.
+
+## OCI garbage collection
+
+OCI garbage collection uses mark and sweep. It starts from every repository tag, recursively follows image indexes and manifests, and deletes only blobs that are not reachable from that graph. A minimum age protects uploads that are still in progress. Dry-run mode is the default.
+
+Configure the scheduler under `Feed:Operations:OciGarbageCollection`:
+
+```json
+{
+  "Feed": {
+    "Operations": {
+      "OciGarbageCollection": {
+        "Enabled": true,
+        "DryRun": true,
+        "Interval": "1.00:00:00",
+        "MinimumAge": "1.00:00:00"
+      }
+    }
+  }
+}
+```
+
+Recommended rollout:
+
+1. Enable the scheduler with `DryRun` set to `true`.
+2. Review the structured GC logs for at least one full retention interval. Each run reports the feed, OCI segment, candidate count, candidate bytes, and dry-run state.
+3. Confirm that `MinimumAge` exceeds the longest expected image push duration.
+4. Set `DryRun` to `false` after the candidate set is understood.
+5. Monitor `blob_bytes_stored{type="oci"}` and storage-provider capacity alerts.
+
+GC processes each OCI surface independently. A failure reading a reachable manifest aborts that surface's run before any candidate is selected, preventing collection from continuing with an incomplete reference graph. Deletions are persisted one blob at a time so a later storage failure does not leave earlier deletions recorded only in memory.
+
+NuGet prerelease retention is configured separately under `Retention`; see the retention settings in the [configuration guide](configuration.md). Storage quotas are not enforced by an application quota UI. Use storage-provider quotas and alerts together with `blob_bytes_stored`.
+
+## API key rotation
+
+Rotate feed keys without downtime:
+
+1. Create a replacement token under **API Keys** with the same required scopes.
+2. Update clients, CI secrets, and registry credentials to use the replacement.
+3. Verify successful package restore and publish operations in the audit log.
+4. Revoke the old token under **API Keys**.
+5. Remove the old value from every external secret store.
+
+Use short-lived tokens where practical. Never place tokens in image layers, source control, command history, or Prometheus labels.
+
+## Production transport and audit
+
+Terminate TLS at Kestrel or a trusted reverse proxy and forward the original scheme and host. Production public URLs must be HTTPS. Restrict administration pages, health details, and metrics to trusted networks.
+
+The host records package publication and group promotion events in its audit log and can dispatch configured webhooks. Review the audit log after key rotation, GC configuration changes, and failed downstream publishing attempts.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -80,7 +80,7 @@ const sidebars: SidebarsConfig = {
             type: 'category',
             label: 'Deployment',
             collapsible: true,
-            items: ['hosting', 'host/host-email'],
+            items: ['hosting', 'operations', 'host/host-email'],
         },
         {
             type: 'category',

--- a/src/AvantiPoint.Feed.Platform/AvantiPoint.Feed.Platform.csproj
+++ b/src/AvantiPoint.Feed.Platform/AvantiPoint.Feed.Platform.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="prometheus-net" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AvantiPoint.Feed.Platform/Extensions/FeedServiceCollectionExtensions.cs
+++ b/src/AvantiPoint.Feed.Platform/Extensions/FeedServiceCollectionExtensions.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Prometheus;
 
 namespace AvantiPoint.Feed.Platform.Extensions;
 
@@ -38,7 +39,10 @@ public static class FeedServiceCollectionExtensions
         services.TryAddEnumerable(ServiceDescriptor.Scoped<IFeedProtocolAuthenticationAdapter, OciFeedAuthenticationAdapter>());
         services.TryAddScoped<IFeedAuthenticationService, CompositeFeedAuthenticationService>();
         services.TryAddSingleton<IMirrorPolicyService, ConfigurableMirrorPolicyService>();
+        services.TryAddSingleton<IMetricFactory>(_ => Prometheus.Metrics.DefaultFactory);
         services.TryAddSingleton<FeedMetricsService>();
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IProtocolNeutralFeedActionHandler, FeedMetricsActionHandler>());
+        services.AddHealthChecks();
 
         services.TryAddSingleton(CreateDefaultFeedRegistry);
 

--- a/src/AvantiPoint.Feed.Platform/Health/FeedHealthExtensions.cs
+++ b/src/AvantiPoint.Feed.Platform/Health/FeedHealthExtensions.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 namespace AvantiPoint.Feed.Platform.Health;
 
@@ -10,29 +11,73 @@ public static class FeedHealthExtensions
 {
     public static IEndpointRouteBuilder MapFeedHealthEndpoints(this IEndpointRouteBuilder endpoints)
     {
-        endpoints.MapGet("/health/feeds", (IFeedRegistry registry, FeedMetricsService metrics) =>
-        {
-            var surfaces = registry.Surfaces.Select(s => new
-            {
-                s.SurfaceId,
-                Protocol = s.Protocol.ToString(),
-                s.OciSegment,
-                s.RoutePrefix,
-                Status = "ready",
-            });
-
-            return Results.Json(new
-            {
-                feedId = registry.Feed.FeedId,
-                surfaces,
-                metrics = new
-                {
-                    push = metrics.GetPushCounts(),
-                    pull = metrics.GetPullCounts(),
-                },
-            });
-        });
+        endpoints.MapGet("/health/feeds", GetFeedHealthAsync);
+        endpoints.MapGet("/health/feeds/{name}", GetNamedFeedHealthAsync);
 
         return endpoints;
+    }
+
+    private static Task<IResult> GetFeedHealthAsync(
+        IFeedRegistry registry,
+        FeedMetricsService metrics,
+        HealthCheckService healthChecks,
+        CancellationToken cancellationToken) =>
+        BuildResponseAsync(registry, metrics, healthChecks, cancellationToken);
+
+    private static Task<IResult> GetNamedFeedHealthAsync(
+        string name,
+        IFeedRegistry registry,
+        FeedMetricsService metrics,
+        HealthCheckService healthChecks,
+        CancellationToken cancellationToken)
+    {
+        if (!string.Equals(name, registry.Feed.FeedId, StringComparison.OrdinalIgnoreCase))
+        {
+            return Task.FromResult<IResult>(Results.NotFound());
+        }
+
+        return BuildResponseAsync(registry, metrics, healthChecks, cancellationToken);
+    }
+
+    private static async Task<IResult> BuildResponseAsync(
+        IFeedRegistry registry,
+        FeedMetricsService metrics,
+        HealthCheckService healthChecks,
+        CancellationToken cancellationToken)
+    {
+        var report = await healthChecks.CheckHealthAsync(cancellationToken);
+        var response = new
+        {
+            feedId = registry.Feed.FeedId,
+            status = report.Status.ToString().ToLowerInvariant(),
+            surfaces = registry.Surfaces.Select(surface => new
+            {
+                surface.SurfaceId,
+                protocol = surface.Protocol.ToString(),
+                surface.OciSegment,
+                surface.RoutePrefix,
+                status = report.Status == HealthStatus.Healthy ? "ready" : "not-ready",
+            }),
+            checks = report.Entries.ToDictionary(
+                entry => entry.Key,
+                entry => new
+                {
+                    status = entry.Value.Status.ToString().ToLowerInvariant(),
+                    entry.Value.Description,
+                    durationMilliseconds = entry.Value.Duration.TotalMilliseconds,
+                }),
+            metrics = new
+            {
+                push = metrics.GetPushCounts(),
+                pull = metrics.GetPullCounts(),
+                blobBytes = metrics.GetBlobBytes(),
+            },
+        };
+
+        return Results.Json(
+            response,
+            statusCode: report.Status == HealthStatus.Healthy
+                ? StatusCodes.Status200OK
+                : StatusCodes.Status503ServiceUnavailable);
     }
 }

--- a/src/AvantiPoint.Feed.Platform/Metrics/FeedMetricsActionHandler.cs
+++ b/src/AvantiPoint.Feed.Platform/Metrics/FeedMetricsActionHandler.cs
@@ -1,0 +1,31 @@
+using AvantiPoint.Feed.Platform.Callbacks;
+
+namespace AvantiPoint.Feed.Platform.Metrics;
+
+/// <summary>
+/// Records completed artifact operations after protocol handlers have committed the operation.
+/// The handler has no access-control opinion and is excluded from authorization voting.
+/// </summary>
+public sealed class FeedMetricsActionHandler(FeedMetricsService metrics) : IProtocolNeutralFeedActionHandler
+{
+    public Task<bool> CanAccessArtifact(
+        FeedArtifactEventContext context,
+        CancellationToken cancellationToken = default) =>
+        Task.FromResult(true);
+
+    public Task OnArtifactDownloaded(
+        FeedArtifactEventContext context,
+        CancellationToken cancellationToken = default)
+    {
+        metrics.RecordPull(context.Surface);
+        return Task.CompletedTask;
+    }
+
+    public Task OnArtifactUploaded(
+        FeedArtifactEventContext context,
+        CancellationToken cancellationToken = default)
+    {
+        metrics.RecordPush(context.Surface);
+        return Task.CompletedTask;
+    }
+}

--- a/src/AvantiPoint.Feed.Platform/Metrics/FeedMetricsService.cs
+++ b/src/AvantiPoint.Feed.Platform/Metrics/FeedMetricsService.cs
@@ -1,26 +1,94 @@
 using System.Collections.Concurrent;
-using AvantiPoint.Feed.Platform;
+using Prometheus;
 
 namespace AvantiPoint.Feed.Platform.Metrics;
 
 public sealed class FeedMetricsService
 {
-    private readonly ConcurrentDictionary<string, long> _pushCounts = new(StringComparer.OrdinalIgnoreCase);
-    private readonly ConcurrentDictionary<string, long> _pullCounts = new(StringComparer.OrdinalIgnoreCase);
+    private static readonly string[] LabelNames = ["feed", "type"];
 
-    public void RecordPush(SurfaceContext surface, string artifact) =>
-        Increment(_pushCounts, BuildKey(surface, artifact));
+    private readonly ConcurrentDictionary<FeedMetricKey, long> _pushCounts = new();
+    private readonly ConcurrentDictionary<FeedMetricKey, long> _pullCounts = new();
+    private readonly ConcurrentDictionary<FeedMetricKey, long> _blobBytes = new();
+    private readonly Counter _pushCounter;
+    private readonly Counter _pullCounter;
+    private readonly Gauge _blobBytesGauge;
 
-    public void RecordPull(SurfaceContext surface, string artifact) =>
-        Increment(_pullCounts, BuildKey(surface, artifact));
+    public FeedMetricsService(IMetricFactory metricFactory)
+    {
+        _pushCounter = metricFactory.CreateCounter(
+            "feed_push_total",
+            "Completed artifact pushes by feed and protocol.",
+            LabelNames);
+        _pullCounter = metricFactory.CreateCounter(
+            "feed_pull_total",
+            "Completed artifact pulls by feed and protocol.",
+            LabelNames);
+        _blobBytesGauge = metricFactory.CreateGauge(
+            "blob_bytes_stored",
+            "Bytes currently stored in content-addressed blob storage by feed and protocol.",
+            LabelNames);
+    }
 
-    public IReadOnlyDictionary<string, long> GetPushCounts() => _pushCounts;
+    public void RecordPush(SurfaceContext surface)
+    {
+        var key = FeedMetricKey.From(surface);
+        Increment(_pushCounts, key);
+        _pushCounter.WithLabels(key.FeedId, key.Protocol).Inc();
+    }
 
-    public IReadOnlyDictionary<string, long> GetPullCounts() => _pullCounts;
+    public void RecordPull(SurfaceContext surface)
+    {
+        var key = FeedMetricKey.From(surface);
+        Increment(_pullCounts, key);
+        _pullCounter.WithLabels(key.FeedId, key.Protocol).Inc();
+    }
 
-    private static void Increment(ConcurrentDictionary<string, long> counts, string key) =>
+    public void RecordBlobBytes(SurfaceContext surface, long delta)
+        => RecordBlobBytes(surface.FeedId, surface.Protocol, delta);
+
+    public void RecordBlobBytes(string feedId, FeedProtocol protocol, long delta)
+    {
+        var key = FeedMetricKey.From(feedId, protocol);
+        var current = _blobBytes.AddOrUpdate(
+            key,
+            _ => Math.Max(0, delta),
+            (_, value) => Math.Max(0, value + delta));
+        _blobBytesGauge.WithLabels(key.FeedId, key.Protocol).Set(current);
+    }
+
+    public void SetBlobBytes(SurfaceContext surface, long value)
+        => SetBlobBytes(surface.FeedId, surface.Protocol, value);
+
+    public void SetBlobBytes(string feedId, FeedProtocol protocol, long value)
+    {
+        var key = FeedMetricKey.From(feedId, protocol);
+        var current = Math.Max(0, value);
+        _blobBytes[key] = current;
+        _blobBytesGauge.WithLabels(key.FeedId, key.Protocol).Set(current);
+    }
+
+    public IReadOnlyDictionary<string, long> GetPushCounts() => Snapshot(_pushCounts);
+
+    public IReadOnlyDictionary<string, long> GetPullCounts() => Snapshot(_pullCounts);
+
+    public IReadOnlyDictionary<string, long> GetBlobBytes() => Snapshot(_blobBytes);
+
+    private static void Increment(ConcurrentDictionary<FeedMetricKey, long> counts, FeedMetricKey key) =>
         counts.AddOrUpdate(key, 1, (_, current) => current + 1);
 
-    private static string BuildKey(SurfaceContext surface, string artifact) =>
-        $"{surface.FeedId}:{surface.Protocol}:{surface.OciSegment ?? "default"}:{artifact}";
+    private static IReadOnlyDictionary<string, long> Snapshot(
+        ConcurrentDictionary<FeedMetricKey, long> values) =>
+        values.ToDictionary(pair => pair.Key.ToString(), pair => pair.Value, StringComparer.OrdinalIgnoreCase);
+
+    private readonly record struct FeedMetricKey(string FeedId, string Protocol)
+    {
+        public static FeedMetricKey From(SurfaceContext surface) =>
+            From(surface.FeedId, surface.Protocol);
+
+        public static FeedMetricKey From(string feedId, FeedProtocol protocol) =>
+            new(feedId, protocol.ToString().ToLowerInvariant());
+
+        public override string ToString() => $"{FeedId}:{Protocol}";
+    }
 }

--- a/src/AvantiPoint.Packages.Registry.Oci/OciGarbageCollectionHostedService.cs
+++ b/src/AvantiPoint.Packages.Registry.Oci/OciGarbageCollectionHostedService.cs
@@ -1,0 +1,68 @@
+using AvantiPoint.Feed.Platform;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace AvantiPoint.Packages.Registry.Oci;
+
+internal sealed class OciGarbageCollectionHostedService(
+    IServiceScopeFactory scopeFactory,
+    IFeedRegistry registry,
+    IOptionsMonitor<OciGarbageCollectionOptions> options,
+    ILogger<OciGarbageCollectionHostedService> logger) : BackgroundService
+{
+    private static readonly TimeSpan DisabledPollInterval = TimeSpan.FromMinutes(5);
+    private static readonly TimeSpan MinimumInterval = TimeSpan.FromMinutes(1);
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            var current = options.CurrentValue;
+            if (current.Enabled)
+            {
+                await CollectAsync(current, stoppingToken);
+            }
+
+            var interval = current.Enabled ? current.Interval : DisabledPollInterval;
+            if (interval < MinimumInterval)
+            {
+                interval = MinimumInterval;
+            }
+
+            await Task.Delay(interval, stoppingToken);
+        }
+    }
+
+    private async Task CollectAsync(
+        OciGarbageCollectionOptions current,
+        CancellationToken cancellationToken)
+    {
+        foreach (var surface in registry.Surfaces.Where(surface => surface.Protocol == FeedProtocol.Oci))
+        {
+            try
+            {
+                using var scope = scopeFactory.CreateScope();
+                var collector = scope.ServiceProvider.GetRequiredService<OciGarbageCollectionService>();
+                await collector.CollectAsync(
+                    new OciScope(registry.Feed.FeedId, surface.OciSegment),
+                    current.DryRun,
+                    current.MinimumAge,
+                    cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception exception)
+            {
+                logger.LogError(
+                    exception,
+                    "OCI garbage collection failed for feed {FeedId} surface {SurfaceId}",
+                    registry.Feed.FeedId,
+                    surface.SurfaceId);
+            }
+        }
+    }
+}

--- a/src/AvantiPoint.Packages.Registry.Oci/OciGarbageCollectionOptions.cs
+++ b/src/AvantiPoint.Packages.Registry.Oci/OciGarbageCollectionOptions.cs
@@ -1,0 +1,15 @@
+namespace AvantiPoint.Packages.Registry.Oci;
+
+/// <summary>
+/// Controls scheduled OCI garbage collection. Collection is disabled and dry-run-only by default.
+/// </summary>
+public sealed class OciGarbageCollectionOptions
+{
+    public bool Enabled { get; set; }
+
+    public bool DryRun { get; set; } = true;
+
+    public TimeSpan Interval { get; set; } = TimeSpan.FromHours(24);
+
+    public TimeSpan MinimumAge { get; set; } = TimeSpan.FromHours(24);
+}

--- a/src/AvantiPoint.Packages.Registry.Oci/OciGarbageCollectionService.cs
+++ b/src/AvantiPoint.Packages.Registry.Oci/OciGarbageCollectionService.cs
@@ -1,50 +1,162 @@
 using AvantiPoint.Feed.Platform;
+using AvantiPoint.Feed.Platform.Metrics;
+using AvantiPoint.Feed.Platform.Storage;
 using AvantiPoint.Packages.Core;
 using AvantiPoint.Packages.Core.Entities.Oci;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 
 namespace AvantiPoint.Packages.Registry.Oci;
 
-public sealed class OciGarbageCollectionService
+/// <summary>
+/// Reclaims OCI content that is no longer reachable from any repository tag. Reachability is
+/// calculated through the complete manifest graph before any content is deleted.
+/// </summary>
+public sealed class OciGarbageCollectionService(
+    IContext context,
+    IStorageBackendFactory storageFactory,
+    FeedMetricsService metrics,
+    TimeProvider timeProvider,
+    ILogger<OciGarbageCollectionService> logger)
 {
-    private readonly IContext _context;
-
-    public OciGarbageCollectionService(IContext context)
-    {
-        _context = context;
-    }
-
     public async Task<OciGarbageCollectionResult> CollectAsync(
         SurfaceContext surface,
         bool dryRun = true,
-        CancellationToken cancellationToken = default)
-    {
-        var scope = new OciScope(surface.FeedId, surface.OciSegment);
-        var referencedDigests = await GetReferencedDigestsAsync(scope, cancellationToken);
-        var blobs = await _context.OciBlobs
-            .Where(b => b.FeedId == scope.FeedId && b.OciSegment == scope.OciSegment)
-            .ToListAsync(cancellationToken);
+        TimeSpan? minimumAge = null,
+        CancellationToken cancellationToken = default) =>
+        await CollectAsync(
+            new OciScope(surface.FeedId, surface.OciSegment),
+            dryRun,
+            minimumAge,
+            cancellationToken);
 
-        var orphaned = blobs.Where(b => !referencedDigests.Contains(b.Digest)).ToList();
-        if (!dryRun)
+    internal async Task<OciGarbageCollectionResult> CollectAsync(
+        OciScope scope,
+        bool dryRun,
+        TimeSpan? minimumAge,
+        CancellationToken cancellationToken)
+    {
+        var retentionAge = minimumAge ?? TimeSpan.FromHours(24);
+        if (retentionAge < TimeSpan.Zero)
         {
-            throw new NotSupportedException(
-                "OCI garbage collection delete mode is not supported until manifest and layer reference "
-                + "graph traversal is implemented. Use dryRun: true.");
+            throw new ArgumentOutOfRangeException(nameof(minimumAge), "Minimum age cannot be negative.");
         }
 
-        return new OciGarbageCollectionResult(orphaned.Count, orphaned.Select(b => b.Digest).ToList(), Deleted: false);
-    }
-
-    private async Task<HashSet<string>> GetReferencedDigestsAsync(OciScope scope, CancellationToken cancellationToken)
-    {
-        var tagDigests = await _context.OciTags
-            .Where(t => t.FeedId == scope.FeedId && t.OciSegment == scope.OciSegment)
-            .Select(t => t.ManifestDigest)
+        var blobs = await context.OciBlobs
+            .Where(blob => blob.FeedId == scope.FeedId && blob.OciSegment == scope.OciSegment)
+            .ToListAsync(cancellationToken);
+        var manifests = await context.OciManifests
+            .Where(manifest => manifest.FeedId == scope.FeedId && manifest.OciSegment == scope.OciSegment)
+            .ToListAsync(cancellationToken);
+        var roots = await context.OciTags
+            .Where(tag => tag.FeedId == scope.FeedId && tag.OciSegment == scope.OciSegment)
+            .Select(tag => tag.ManifestDigest)
+            .Distinct()
             .ToListAsync(cancellationToken);
 
-        return tagDigests.ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var store = storageFactory.CreateDigestStore(
+            OciSurfaceOptionsBuilder.GetStorageSubPrefix(scope.OciSegment));
+        var reachable = await FindReachableDigestsAsync(
+            roots,
+            manifests,
+            store,
+            cancellationToken);
+        var cutoff = timeProvider.GetUtcNow().UtcDateTime - retentionAge;
+        var orphaned = blobs
+            .Where(blob => blob.CreatedAt <= cutoff && !reachable.Contains(blob.Digest))
+            .OrderBy(blob => blob.Digest, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        var bytes = orphaned.Sum(blob => blob.Size);
+
+        logger.LogInformation(
+            "OCI garbage collection found {BlobCount} orphaned blobs totaling {BlobBytes} bytes on feed {FeedId} segment {Segment}; DryRun={DryRun}",
+            orphaned.Count,
+            bytes,
+            scope.FeedId,
+            scope.OciSegment ?? "(default)",
+            dryRun);
+
+        if (!dryRun)
+        {
+            var manifestsByDigest = manifests
+                .GroupBy(manifest => manifest.Digest, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(group => group.Key, group => group.ToList(), StringComparer.OrdinalIgnoreCase);
+            foreach (var blob in orphaned)
+            {
+                var (algorithm, hex) = DigestBlobStore.ParseDigest(blob.Digest);
+                if (await store.ExistsAsync(algorithm, hex, cancellationToken))
+                {
+                    await store.DeleteAsync(algorithm, hex, cancellationToken);
+                }
+
+                if (manifestsByDigest.TryGetValue(blob.Digest, out var orphanedManifests))
+                {
+                    context.OciManifests.RemoveRange(orphanedManifests);
+                }
+
+                context.OciBlobs.Remove(blob);
+                await context.SaveChangesAsync(cancellationToken);
+                metrics.RecordBlobBytes(scope.FeedId, FeedProtocol.Oci, -blob.Size);
+            }
+        }
+
+        return new OciGarbageCollectionResult(
+            orphaned.Count,
+            orphaned.Select(blob => blob.Digest).ToList(),
+            Deleted: !dryRun)
+        {
+            Bytes = bytes,
+        };
+    }
+
+    private static async Task<HashSet<string>> FindReachableDigestsAsync(
+        IEnumerable<string> roots,
+        IReadOnlyCollection<OciManifest> manifests,
+        IDigestBlobStore store,
+        CancellationToken cancellationToken)
+    {
+        var manifestsByDigest = manifests
+            .GroupBy(manifest => manifest.Digest, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(group => group.Key, group => group.First(), StringComparer.OrdinalIgnoreCase);
+        var reachable = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var pending = new Queue<string>();
+        foreach (var root in roots)
+        {
+            if (reachable.Add(root))
+            {
+                pending.Enqueue(root);
+            }
+        }
+
+        while (pending.TryDequeue(out var digest))
+        {
+            if (!manifestsByDigest.TryGetValue(digest, out var manifest))
+            {
+                continue;
+            }
+
+            var (algorithm, hex) = DigestBlobStore.ParseDigest(digest);
+            await using var stream = await store.GetAsync(algorithm, hex, cancellationToken);
+            using var content = new MemoryStream();
+            await stream.CopyToAsync(content, cancellationToken);
+            var parsed = OciManifestParser.Parse(manifest.MediaType, content.ToArray());
+            foreach (var referencedDigest in parsed.ReferencedDigests)
+            {
+                if (reachable.Add(referencedDigest))
+                {
+                    pending.Enqueue(referencedDigest);
+                }
+            }
+        }
+
+        return reachable;
     }
 }
 
-public sealed record OciGarbageCollectionResult(int Count, IReadOnlyList<string> Digests, bool Deleted);
+public sealed record OciGarbageCollectionResult(
+    int Count,
+    IReadOnlyList<string> Digests,
+    bool Deleted)
+{
+    public long Bytes { get; init; }
+}

--- a/src/AvantiPoint.Packages.Registry.Oci/OciRegistryEndpoints.cs
+++ b/src/AvantiPoint.Packages.Registry.Oci/OciRegistryEndpoints.cs
@@ -26,6 +26,10 @@ public static class OciRegistryEndpoints
         services.AddScoped<IOciRegistryService, OciRegistryService>();
         services.AddSingleton<OciFeedOptionsAccessor>();
         services.AddScoped<OciGarbageCollectionService>();
+        services.AddOptions<OciGarbageCollectionOptions>();
+        services.TryAddSingleton(TimeProvider.System);
+        services.AddHostedService<OciGarbageCollectionHostedService>();
+        services.AddHostedService<OciStorageMetricsInitializer>();
         return services;
     }
 
@@ -121,7 +125,13 @@ public static class OciRegistryEndpoints
         var method = httpContext.Request.Method;
         if (route.Kind == OciRouteKind.Manifest && method == HttpMethods.Get)
         {
-            return await HandleGetManifest(httpContext.Response, service, surface, route, cancellationToken);
+            return await HandleGetManifest(
+                httpContext.Response,
+                service,
+                surface,
+                route,
+                actionHandler,
+                cancellationToken);
         }
 
         if (route.Kind == OciRouteKind.Manifest && method == HttpMethods.Head)
@@ -175,12 +185,23 @@ public static class OciRegistryEndpoints
         IOciRegistryService service,
         SurfaceContext surface,
         OciRoute route,
+        IFeedActionHandler? actionHandler,
         CancellationToken cancellationToken)
     {
         var manifest = await service.GetManifestAsync(surface, route.RepositoryName!, route.Reference!, cancellationToken);
         if (manifest is null)
         {
             return Results.NotFound();
+        }
+
+        if (actionHandler is not null && !route.Reference!.Contains(':', StringComparison.Ordinal))
+        {
+            var eventContext = new FeedArtifactEventContext(
+                surface,
+                route.RepositoryName!,
+                route.Reference,
+                manifest.Digest);
+            await actionHandler.OnArtifactDownloaded(eventContext, cancellationToken);
         }
 
         ApplyManifestHeaders(response, manifest.Digest, manifest.MediaType);

--- a/src/AvantiPoint.Packages.Registry.Oci/OciRegistryService.cs
+++ b/src/AvantiPoint.Packages.Registry.Oci/OciRegistryService.cs
@@ -68,7 +68,6 @@ public sealed class OciRegistryService : IOciRegistryService
         using var memory = new MemoryStream();
         await stream.CopyToAsync(memory, cancellationToken);
 
-        _metrics.RecordPull(surface, repositoryName);
         return new OciManifestResult(digest, manifest.MediaType, memory.ToArray());
     }
 
@@ -105,6 +104,7 @@ public sealed class OciRegistryService : IOciRegistryService
         {
             await store.PutAsync(algorithm, hex, buffer, cancellationToken);
             await EnsureBlobRecordAsync(scope, digest, bytes.Length, cancellationToken);
+            _metrics.RecordBlobBytes(surface, bytes.Length);
         }
 
         foreach (var referencedDigest in parsed.ReferencedDigests)
@@ -120,7 +120,6 @@ public sealed class OciRegistryService : IOciRegistryService
 
         await UpsertTagAsync(scope, repositoryName, reference, digest, PackageOrigin.Published, cancellationToken);
 
-        _metrics.RecordPush(surface, repositoryName);
         _logger.LogInformation(
             "Published OCI manifest {Digest} to {Repository} on feed {FeedId} segment {Segment}",
             digest,
@@ -152,7 +151,6 @@ public sealed class OciRegistryService : IOciRegistryService
         {
             var stream = await store.GetAsync(algorithm, hex, cancellationToken);
             var size = blob?.Size ?? stream.Length;
-            _metrics.RecordPull(surface, digest);
             return new OciBlobResult(digest, stream, size);
         }
 
@@ -186,6 +184,7 @@ public sealed class OciRegistryService : IOciRegistryService
                 upstreamStream.Position = 0;
                 await store.PutAsync(algorithm, hex, upstreamStream, cancellationToken);
                 await EnsureBlobRecordAsync(scope, digest, upstreamStream.Length, cancellationToken);
+                _metrics.RecordBlobBytes(surface, upstreamStream.Length);
             }
 
             if (!await store.ExistsAsync(algorithm, hex, cancellationToken))
@@ -198,11 +197,9 @@ public sealed class OciRegistryService : IOciRegistryService
             var persisted = await _context.OciBlobs.AsNoTracking().FirstOrDefaultAsync(
                 b => b.FeedId == scope.FeedId && b.OciSegment == scope.OciSegment && b.Digest == digest,
                 cancellationToken);
-            _metrics.RecordPull(surface, digest);
             return new OciBlobResult(digest, stream, persisted?.Size ?? stream.Length);
         }
 
-        _metrics.RecordPull(surface, digest);
         return new OciBlobResult(digest, upstreamStream, upstreamStream.Length);
     }
 
@@ -367,15 +364,19 @@ public sealed class OciRegistryService : IOciRegistryService
                 $"Upload digest does not match blob content. Expected '{digest}', computed '{computedDigest}'.");
         }
 
+        var wasStored = await digestStore.ExistsAsync(algorithm, hex, cancellationToken);
         buffer.Position = 0;
         await digestStore.PutAsync(algorithm, hex, buffer, cancellationToken);
         await EnsureBlobRecordAsync(scope, digest, buffer.Length, cancellationToken);
+        if (!wasStored)
+        {
+            _metrics.RecordBlobBytes(surface, buffer.Length);
+        }
 
         await pathStore.DeleteAsync(upload.StoragePath, cancellationToken);
         _context.OciUploads.Remove(upload);
         await _context.SaveChangesAsync(cancellationToken);
 
-        _metrics.RecordPush(surface, repositoryName);
         return new OciCompleteUploadResult(digest, BuildBlobLocation(surface, repositoryName, digest));
     }
 
@@ -481,7 +482,6 @@ public sealed class OciRegistryService : IOciRegistryService
             return await GetManifestAsync(surface, repositoryName, reference, cancellationToken);
         }
 
-        _metrics.RecordPull(surface, repositoryName);
         return new OciManifestResult(upstream.Digest, upstream.MediaType, upstream.Content);
     }
 
@@ -517,6 +517,7 @@ public sealed class OciRegistryService : IOciRegistryService
         {
             await store.PutAsync(algorithm, hex, buffer, cancellationToken);
             await EnsureBlobRecordAsync(scope, digest, upstream.Content.Length, cancellationToken);
+            _metrics.RecordBlobBytes(surface, upstream.Content.Length);
         }
 
         var origin = _mirror.MirrorOrigin(surface);
@@ -524,7 +525,6 @@ public sealed class OciRegistryService : IOciRegistryService
         await EnsureRepositoryAsync(scope, repositoryName, cancellationToken);
         await UpsertTagAsync(scope, repositoryName, reference, digest, origin, cancellationToken);
 
-        _metrics.RecordPull(surface, repositoryName);
         _logger.LogInformation(
             "Mirrored OCI manifest {Digest} to {Repository} on feed {FeedId} segment {Segment}",
             digest,

--- a/src/AvantiPoint.Packages.Registry.Oci/OciStorageMetricsInitializer.cs
+++ b/src/AvantiPoint.Packages.Registry.Oci/OciStorageMetricsInitializer.cs
@@ -1,0 +1,48 @@
+using AvantiPoint.Feed.Platform;
+using AvantiPoint.Feed.Platform.Metrics;
+using AvantiPoint.Packages.Core;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace AvantiPoint.Packages.Registry.Oci;
+
+internal sealed class OciStorageMetricsInitializer(
+    IServiceScopeFactory scopeFactory,
+    IFeedRegistry registry,
+    FeedMetricsService metrics,
+    ILogger<OciStorageMetricsInitializer> logger) : IHostedService
+{
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (!registry.Surfaces.Any(surface => surface.Protocol == FeedProtocol.Oci))
+        {
+            return;
+        }
+
+        try
+        {
+            using var scope = scopeFactory.CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<IContext>();
+            var value = await context.OciBlobs
+                .AsNoTracking()
+                .Where(blob => blob.FeedId == registry.Feed.FeedId)
+                .SumAsync(blob => blob.Size, cancellationToken);
+            metrics.SetBlobBytes(registry.Feed.FeedId, FeedProtocol.Oci, value);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            logger.LogWarning(
+                exception,
+                "OCI storage metrics could not be initialized for feed {FeedId}",
+                registry.Feed.FeedId);
+        }
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/host/AvantiPoint.Packages.Host/AvantiPoint.Packages.Host.csproj
+++ b/src/host/AvantiPoint.Packages.Host/AvantiPoint.Packages.Host.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" PrivateAssets="all" />
+    <PackageReference Include="prometheus-net.AspNetCore" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/host/AvantiPoint.Packages.Host/Program.cs
+++ b/src/host/AvantiPoint.Packages.Host/Program.cs
@@ -1,5 +1,6 @@
 using AvantiPoint.Feed.Platform;
 using AvantiPoint.Feed.Platform.Extensions;
+using AvantiPoint.Feed.Platform.Health;
 using AvantiPoint.Packages;
 using AvantiPoint.Packages.Host.Admin.Configuration;
 using AvantiPoint.Packages.Host.Admin.Extensions;
@@ -7,8 +8,10 @@ using AvantiPoint.Packages.Host.Extensions;
 using AvantiPoint.Packages.Hosting;
 using AvantiPoint.Packages.Registry.Npm.Extensions;
 using AvantiPoint.Packages.Registry.Oci.Extensions;
+using AvantiPoint.Packages.Registry.Oci;
 using AvantiPoint.Packages.UI;
 using Microsoft.AspNetCore.Authorization;
+using Prometheus;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -22,6 +25,8 @@ builder.Services.AddHostAdminServices(builder.Configuration);
 builder.Services.AddHostDatabaseUpstreamProviders();
 builder.Services.AddHostIdentityDatabase(builder.Configuration);
 builder.Services.AddHostDatabaseHealthChecks();
+builder.Services.Configure<OciGarbageCollectionOptions>(
+    builder.Configuration.GetSection("Feed:Operations:OciGarbageCollection"));
 
 var authOptions = builder.Configuration.GetSection("Host:Authentication").Get<HostAuthenticationOptions>()
     ?? new HostAuthenticationOptions();
@@ -81,6 +86,8 @@ await app.InitializeHostDatabasesAsync();
 
 app.MapDefaultEndpoints();
 app.MapHealthChecks("/health");
+app.MapFeedHealthEndpoints();
+app.MapMetrics();
 
 if (app.Environment.IsDevelopment())
 {

--- a/tests/AvantiPoint.Packages.Integration.Tests/CrossFeedIsolationIntegrationTests.cs
+++ b/tests/AvantiPoint.Packages.Integration.Tests/CrossFeedIsolationIntegrationTests.cs
@@ -114,6 +114,35 @@ public sealed class CrossFeedIsolationIntegrationTests
         Assert.Equal(HttpStatusCode.OK, helmEmbedded.StatusCode);
     }
 
+    [Fact]
+    public async Task NamedFeedHealth_ReportsRegisteredSurfacesAndRejectsUnknownFeed()
+    {
+        await using var host = await FeedTestServerHost.StartAsync();
+
+        using var response = await host.Client.GetAsync(
+            "/health/feeds/default",
+            TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        using var document = JsonDocument.Parse(
+            await response.Content.ReadAsStreamAsync(TestContext.Current.CancellationToken));
+        Assert.Equal("default", document.RootElement.GetProperty("feedId").GetString());
+        Assert.Equal("healthy", document.RootElement.GetProperty("status").GetString());
+        Assert.Contains(
+            document.RootElement.GetProperty("surfaces").EnumerateArray(),
+            surface => surface.GetProperty("protocol").GetString() == "NuGet");
+        Assert.Contains(
+            document.RootElement.GetProperty("surfaces").EnumerateArray(),
+            surface => surface.GetProperty("protocol").GetString() == "Npm");
+        Assert.Contains(
+            document.RootElement.GetProperty("surfaces").EnumerateArray(),
+            surface => surface.GetProperty("protocol").GetString() == "Oci");
+
+        using var missing = await host.Client.GetAsync(
+            "/health/feeds/unknown",
+            TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.NotFound, missing.StatusCode);
+    }
+
     private static IFeedRegistry CreateMultiSurfaceRegistry()
     {
         var feed = new FeedContext("default", "default", "feeds/default/");

--- a/tests/AvantiPoint.Packages.Registry.Oci.Tests/FeedMetricsServiceTests.cs
+++ b/tests/AvantiPoint.Packages.Registry.Oci.Tests/FeedMetricsServiceTests.cs
@@ -1,0 +1,47 @@
+using System.Text;
+using AvantiPoint.Feed.Platform;
+using AvantiPoint.Feed.Platform.Callbacks;
+using AvantiPoint.Feed.Platform.Metrics;
+using Prometheus;
+
+namespace AvantiPoint.Packages.Registry.Oci.Tests;
+
+public sealed class FeedMetricsServiceTests
+{
+    [Fact]
+    public async Task ActionHandler_ExportsLowCardinalityPrometheusMetrics()
+    {
+        var registry = Metrics.NewCustomRegistry();
+        var metrics = new FeedMetricsService(Metrics.WithCustomRegistry(registry));
+        var handler = new FeedMetricsActionHandler(metrics);
+        var surface = new SurfaceContext(
+            "corp",
+            FeedProtocol.Npm,
+            "npm",
+            null,
+            "/npm",
+            new Uri("https://packages.example.test/npm"));
+
+        await handler.OnArtifactUploaded(
+            new FeedArtifactEventContext(surface, "first-package", "1.0.0", null),
+            TestContext.Current.CancellationToken);
+        await handler.OnArtifactUploaded(
+            new FeedArtifactEventContext(surface, "second-package", "2.0.0", null),
+            TestContext.Current.CancellationToken);
+        await handler.OnArtifactDownloaded(
+            new FeedArtifactEventContext(surface, "first-package", "1.0.0", null),
+            TestContext.Current.CancellationToken);
+        metrics.SetBlobBytes("corp", FeedProtocol.Oci, 2048);
+
+        using var output = new MemoryStream();
+        await registry.CollectAndExportAsTextAsync(output, TestContext.Current.CancellationToken);
+        var text = Encoding.UTF8.GetString(output.ToArray());
+
+        Assert.Contains("feed_push_total{feed=\"corp\",type=\"npm\"} 2", text);
+        Assert.Contains("feed_pull_total{feed=\"corp\",type=\"npm\"} 1", text);
+        Assert.Contains("blob_bytes_stored{feed=\"corp\",type=\"oci\"} 2048", text);
+        Assert.DoesNotContain("first-package", text);
+        Assert.DoesNotContain("second-package", text);
+        Assert.Equal(2, metrics.GetPushCounts()["corp:npm"]);
+    }
+}

--- a/tests/AvantiPoint.Packages.Registry.Oci.Tests/OciGarbageCollectionServiceTests.cs
+++ b/tests/AvantiPoint.Packages.Registry.Oci.Tests/OciGarbageCollectionServiceTests.cs
@@ -1,0 +1,237 @@
+using System.Security.Cryptography;
+using System.Text;
+using AvantiPoint.Feed.Platform;
+using AvantiPoint.Feed.Platform.Metrics;
+using AvantiPoint.Feed.Platform.Storage;
+using AvantiPoint.Packages.Core;
+using AvantiPoint.Packages.Core.Entities.Oci;
+using AvantiPoint.Packages.Database.Sqlite;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Prometheus;
+
+namespace AvantiPoint.Packages.Registry.Oci.Tests;
+
+public sealed class OciGarbageCollectionServiceTests : IDisposable
+{
+    private const string ManifestMediaType = "application/vnd.oci.image.manifest.v1+json";
+    private const string IndexMediaType = "application/vnd.oci.image.index.v1+json";
+
+    private readonly DateTimeOffset _now = new(2026, 7, 17, 12, 0, 0, TimeSpan.Zero);
+    private readonly SqliteConnection _connection;
+    private readonly SqliteContext _context;
+    private readonly MemoryDigestStore _store = new();
+    private readonly FeedMetricsService _metrics;
+
+    public OciGarbageCollectionServiceTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+        _context = new SqliteContext(new DbContextOptionsBuilder<SqliteContext>().UseSqlite(_connection).Options);
+        _context.Database.EnsureCreated();
+        _metrics = new FeedMetricsService(Metrics.WithCustomRegistry(Metrics.NewCustomRegistry()));
+    }
+
+    [Fact]
+    public async Task CollectAsync_TraversesManifestGraphAndDeletesOnlyOldOrphans()
+    {
+        var seeded = await SeedGraphAsync();
+        var surface = CreateSurface();
+        _metrics.SetBlobBytes(surface, seeded.TotalBytes);
+        var collector = CreateCollector();
+
+        var dryRun = await collector.CollectAsync(
+            surface,
+            dryRun: true,
+            minimumAge: TimeSpan.FromHours(24),
+            TestContext.Current.CancellationToken);
+
+        Assert.False(dryRun.Deleted);
+        Assert.Equal([seeded.OldOrphanDigest], dryRun.Digests);
+        Assert.Equal(seeded.OldOrphanSize, dryRun.Bytes);
+        Assert.True(_store.Contains(seeded.OldOrphanDigest));
+
+        var deleted = await collector.CollectAsync(
+            surface,
+            dryRun: false,
+            minimumAge: TimeSpan.FromHours(24),
+            TestContext.Current.CancellationToken);
+
+        Assert.True(deleted.Deleted);
+        Assert.Equal([seeded.OldOrphanDigest], deleted.Digests);
+        Assert.False(_store.Contains(seeded.OldOrphanDigest));
+        Assert.True(_store.Contains(seeded.RecentOrphanDigest));
+        Assert.All(seeded.ReachableDigests, digest => Assert.True(_store.Contains(digest)));
+        Assert.False(await _context.OciBlobs.AnyAsync(
+            blob => blob.Digest == seeded.OldOrphanDigest,
+            TestContext.Current.CancellationToken));
+        Assert.Equal(
+            seeded.TotalBytes - seeded.OldOrphanSize,
+            _metrics.GetBlobBytes()["default:oci"]);
+    }
+
+    private OciGarbageCollectionService CreateCollector()
+    {
+        return new OciGarbageCollectionService(
+            _context,
+            new StubStorageBackendFactory(_store),
+            _metrics,
+            new FixedTimeProvider(_now),
+            NullLogger<OciGarbageCollectionService>.Instance);
+    }
+
+    private async Task<SeededGraph> SeedGraphAsync()
+    {
+        var config = Encoding.UTF8.GetBytes("{\"architecture\":\"amd64\",\"os\":\"linux\"}");
+        var layer = Encoding.UTF8.GetBytes("reachable-layer");
+        var configDigest = AddContent(config);
+        var layerDigest = AddContent(layer);
+        var child = Encoding.UTF8.GetBytes(
+            $$"""
+            {"schemaVersion":2,"mediaType":"{{ManifestMediaType}}","config":{"digest":"{{configDigest}}"},"layers":[{"digest":"{{layerDigest}}"}]}
+            """);
+        var childDigest = AddContent(child);
+        var root = Encoding.UTF8.GetBytes(
+            $$"""
+            {"schemaVersion":2,"mediaType":"{{IndexMediaType}}","manifests":[{"digest":"{{childDigest}}"}]}
+            """);
+        var rootDigest = AddContent(root);
+        var oldOrphan = Encoding.UTF8.GetBytes("old-orphan");
+        var recentOrphan = Encoding.UTF8.GetBytes("recent-orphan");
+        var oldOrphanDigest = AddContent(oldOrphan);
+        var recentOrphanDigest = AddContent(recentOrphan);
+        var oldCreatedAt = _now.UtcDateTime - TimeSpan.FromDays(2);
+
+        _context.OciBlobs.AddRange(
+            Blob(rootDigest, root.Length, oldCreatedAt),
+            Blob(childDigest, child.Length, oldCreatedAt),
+            Blob(configDigest, config.Length, oldCreatedAt),
+            Blob(layerDigest, layer.Length, oldCreatedAt),
+            Blob(oldOrphanDigest, oldOrphan.Length, oldCreatedAt),
+            Blob(recentOrphanDigest, recentOrphan.Length, _now.UtcDateTime - TimeSpan.FromHours(1)));
+        _context.OciManifests.AddRange(
+            Manifest(rootDigest, root.Length, IndexMediaType, oldCreatedAt),
+            Manifest(childDigest, child.Length, ManifestMediaType, oldCreatedAt));
+        _context.OciRepositories.Add(new OciRepository
+        {
+            Name = "sample",
+            Tags =
+            [
+                new OciTag
+                {
+                    Tag = "latest",
+                    ManifestDigest = rootDigest,
+                    Origin = PackageOrigin.Published,
+                },
+            ],
+        });
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        return new SeededGraph(
+            [rootDigest, childDigest, configDigest, layerDigest],
+            oldOrphanDigest,
+            oldOrphan.Length,
+            recentOrphanDigest,
+            root.Length + child.Length + config.Length + layer.Length + oldOrphan.Length + recentOrphan.Length);
+    }
+
+    private string AddContent(byte[] content)
+    {
+        var digest = $"sha256:{Convert.ToHexString(SHA256.HashData(content)).ToLowerInvariant()}";
+        _store.Add(digest, content);
+        return digest;
+    }
+
+    private static OciBlob Blob(string digest, long size, DateTime createdAt) => new()
+    {
+        Digest = digest,
+        Size = size,
+        CreatedAt = createdAt,
+    };
+
+    private static OciManifest Manifest(
+        string digest,
+        long size,
+        string mediaType,
+        DateTime createdAt) => new()
+    {
+        Digest = digest,
+        Size = size,
+        MediaType = mediaType,
+        CreatedAt = createdAt,
+    };
+
+    private static SurfaceContext CreateSurface() => new(
+        "default",
+        FeedProtocol.Oci,
+        "oci",
+        null,
+        string.Empty,
+        new Uri("https://registry.example.test"));
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        _connection.Dispose();
+    }
+
+    private sealed record SeededGraph(
+        IReadOnlyList<string> ReachableDigests,
+        string OldOrphanDigest,
+        long OldOrphanSize,
+        string RecentOrphanDigest,
+        long TotalBytes);
+
+    private sealed class FixedTimeProvider(DateTimeOffset now) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => now;
+    }
+
+    private sealed class StubStorageBackendFactory(IDigestBlobStore store) : IStorageBackendFactory
+    {
+        public IPathBlobStore CreatePathStore(string subPrefix) => throw new NotSupportedException();
+
+        public IDigestBlobStore CreateDigestStore(string subPrefix) =>
+            subPrefix == "oci/"
+                ? store
+                : throw new InvalidOperationException($"Unexpected storage prefix '{subPrefix}'.");
+    }
+
+    private sealed class MemoryDigestStore : IDigestBlobStore
+    {
+        private readonly Dictionary<string, byte[]> _content = new(StringComparer.OrdinalIgnoreCase);
+
+        public void Add(string digest, byte[] content) => _content[digest] = content;
+
+        public bool Contains(string digest) => _content.ContainsKey(digest);
+
+        public Task PutAsync(
+            string algorithm,
+            string hex,
+            Stream content,
+            CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<Stream> GetAsync(
+            string algorithm,
+            string hex,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult<Stream>(new MemoryStream(_content[$"{algorithm}:{hex}"], writable: false));
+
+        public Task<bool> ExistsAsync(
+            string algorithm,
+            string hex,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(_content.ContainsKey($"{algorithm}:{hex}"));
+
+        public Task DeleteAsync(
+            string algorithm,
+            string hex,
+            CancellationToken cancellationToken = default)
+        {
+            _content.Remove($"{algorithm}:{hex}");
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/AvantiPoint.Packages.Registry.Oci.Tests/OciRegistryTests.cs
+++ b/tests/AvantiPoint.Packages.Registry.Oci.Tests/OciRegistryTests.cs
@@ -170,6 +170,11 @@ public class OciRegistryTests : IClassFixture<OciTestWebApplicationFactory>
         var getResponse = await client.GetAsync($"/v2/{repository}/manifests/v1");
         Assert.Equal(HttpStatusCode.OK, getResponse.StatusCode);
         Assert.Equal("application/vnd.oci.image.manifest.v1+json", getResponse.Content.Headers.ContentType?.MediaType);
+        Assert.Contains(
+            _factory.ArtifactHandler.Downloads,
+            download => download.ArtifactName == repository
+                        && download.Version == "v1"
+                        && download.DigestOrTarballPath == manifestDigest);
 
         var tagsResponse = await client.GetAsync($"/v2/{repository}/tags/list");
         Assert.Equal(HttpStatusCode.OK, tagsResponse.StatusCode);

--- a/tests/AvantiPoint.Packages.Registry.Oci.Tests/OciTestWebApplicationFactory.cs
+++ b/tests/AvantiPoint.Packages.Registry.Oci.Tests/OciTestWebApplicationFactory.cs
@@ -78,8 +78,11 @@ public sealed class OciTestWebApplicationFactory : WebApplicationFactory<Integra
 public sealed class RecordingArtifactHandler : IProtocolNeutralFeedActionHandler
 {
     private readonly System.Collections.Concurrent.ConcurrentQueue<FeedArtifactEventContext> _uploads = new();
+    private readonly System.Collections.Concurrent.ConcurrentQueue<FeedArtifactEventContext> _downloads = new();
 
     public IReadOnlyList<FeedArtifactEventContext> Uploads => _uploads.ToArray();
+
+    public IReadOnlyList<FeedArtifactEventContext> Downloads => _downloads.ToArray();
 
     public Task<bool> CanAccessArtifact(
         FeedArtifactEventContext context,
@@ -88,8 +91,11 @@ public sealed class RecordingArtifactHandler : IProtocolNeutralFeedActionHandler
 
     public Task OnArtifactDownloaded(
         FeedArtifactEventContext context,
-        CancellationToken cancellationToken = default) =>
-        Task.CompletedTask;
+        CancellationToken cancellationToken = default)
+    {
+        _downloads.Enqueue(context);
+        return Task.CompletedTask;
+    }
 
     public Task OnArtifactUploaded(
         FeedArtifactEventContext context,


### PR DESCRIPTION
## Summary
- export low-cardinality Prometheus metrics for feed pushes, pulls, and OCI storage
- expose host and feed readiness endpoints
- add scheduled, dry-run-first OCI mark-and-sweep garbage collection
- document metrics, health probes, GC rollout, quotas, and key rotation

## Validation
- dotnet test --solution APPackages.slnx -c Release --report-github (477 total, 465 passed, 12 skipped, 0 failed)
- Docusaurus production build

Closes #563