### PR TITLE
Add federated upstream package search

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -325,7 +325,10 @@ Configure upstream package sources to mirror or proxy. In v4, sources are `Packa
   ],
   "Search": {
     "Type": "Database",
-    "IncludeMirroredPackages": true
+    "IncludeMirroredPackages": true,
+    "EnableUpstreamSearch": false,
+    "UpstreamSearchTimeout": "00:00:02",
+    "MergeStrategy": "LocalPreferred"
   }
 }
 ```
@@ -446,6 +449,22 @@ No changes are required when upgrading unless you want a different deployment pa
 #### Search provider type
 
 `Search.Type` selects the search backend: `Database` (default), `Null`, `AzureSearch`, `OpenSearch`, or `Elasticsearch`. External search providers honor the same origin filters via `IncludeMirroredPackages`.
+
+#### Federated upstream search
+
+Set `Search.EnableUpstreamSearch` to `true` to merge each local NuGet search page with live results from enabled upstream `PackageSource` rows. This is useful for lightweight developer feeds that proxy packages without indexing the entire upstream catalog. It is disabled by default, so existing deployments do not make additional network requests.
+
+`UpstreamSearchTimeout` limits the complete upstream operation across all configured sources. If that timeout expires, the request returns the local results. A failure from one source does not discard results from other sources.
+
+`MergeStrategy` accepts these values:
+
+| Value | Behavior |
+|-------|----------|
+| `LocalPreferred` (default) | Return one entry per package ID and retain local metadata when the same ID exists upstream |
+| `Deduplicate` | Return one entry per package ID and select the entry with the highest package version |
+| `Union` | Return all entries in source-priority order, including repeated package IDs |
+
+Federation applies to the NuGet search endpoint only. Autocomplete, version enumeration, and dependent queries continue to use the configured local search provider. Upstream credentials and priority come from the existing `PackageSource` configuration.
 
 ### Repository Package Signing
 

--- a/docs/docs/search/index.md
+++ b/docs/docs/search/index.md
@@ -17,6 +17,12 @@ AvantiPoint Packages supports several search backends. **`Search.Type`** selects
 - **Database** — simplest deployment; search runs against SQL with no extra infrastructure.
 - **Elasticsearch / OpenSearch / Azure AI Search** — better full-text relevance, lower database load on large feeds, and horizontal scaling of search workloads.
 
+## Federated upstream search
+
+Any local search provider can be decorated with opt-in, live upstream NuGet search. Set `Search.EnableUpstreamSearch` to `true`; enabled NuGet package sources are queried in priority order and merged with the local page. The default `LocalPreferred` strategy keeps local metadata when a package ID also appears upstream.
+
+Federated search is intended for lightweight developer and offline-cache deployments. Keep it disabled for deterministic, local-only production search. Configure `Search.UpstreamSearchTimeout` so an unavailable source cannot delay local results. See [Search and discovery](../configuration.md#search-and-discovery) for the complete option reference.
+
 ## Startup reconciliation
 
 When an **external** indexer is active, a background service reindexes packages whose `IndexedWith` is null or does not match the current indexer key. The API starts immediately; search results may be incomplete until reconciliation finishes.

--- a/samples/LightweightFeed/appsettings.json
+++ b/samples/LightweightFeed/appsettings.json
@@ -20,7 +20,10 @@
   },
   "Search": {
     "Type": "Database",
-    "IncludeMirroredPackages": false
+    "IncludeMirroredPackages": false,
+    "EnableUpstreamSearch": true,
+    "UpstreamSearchTimeout": "00:00:02",
+    "MergeStrategy": "LocalPreferred"
   },
   "LocalCache": {
     "Enabled": true,

--- a/src/AvantiPoint.Packages.Core/Configuration/FederatedSearchMergeStrategy.cs
+++ b/src/AvantiPoint.Packages.Core/Configuration/FederatedSearchMergeStrategy.cs
@@ -1,0 +1,22 @@
+namespace AvantiPoint.Packages.Core;
+
+/// <summary>
+/// Controls how a page of local and upstream NuGet search results is combined.
+/// </summary>
+public enum FederatedSearchMergeStrategy
+{
+    /// <summary>
+    /// Return every result from every source, including repeated package IDs.
+    /// </summary>
+    Union,
+
+    /// <summary>
+    /// Return one result per package ID and select the result with the highest package version.
+    /// </summary>
+    Deduplicate,
+
+    /// <summary>
+    /// Return one result per package ID and retain the local result when the ID exists locally.
+    /// </summary>
+    LocalPreferred,
+}

--- a/src/AvantiPoint.Packages.Core/Configuration/SearchOptions.cs
+++ b/src/AvantiPoint.Packages.Core/Configuration/SearchOptions.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace AvantiPoint.Packages.Core;
 
 public class SearchOptions
@@ -17,4 +19,20 @@ public class SearchOptions
     /// When true (default), include published and mirrored packages (never cached-only rows).
     /// </summary>
     public bool IncludeMirroredPackages { get; set; } = true;
+
+    /// <summary>
+    /// When true, NuGet search results are merged with live results from enabled upstream sources.
+    /// </summary>
+    public bool EnableUpstreamSearch { get; set; }
+
+    /// <summary>
+    /// Maximum time allowed for the complete upstream search operation. A timeout returns local
+    /// results without failing the client request.
+    /// </summary>
+    public TimeSpan UpstreamSearchTimeout { get; set; } = TimeSpan.FromSeconds(2);
+
+    /// <summary>
+    /// Controls how local and upstream search results are combined.
+    /// </summary>
+    public FederatedSearchMergeStrategy MergeStrategy { get; set; } = FederatedSearchMergeStrategy.LocalPreferred;
 }

--- a/src/AvantiPoint.Packages.Core/Extensions/DependencyInjectionExtensions.cs
+++ b/src/AvantiPoint.Packages.Core/Extensions/DependencyInjectionExtensions.cs
@@ -32,8 +32,21 @@ namespace AvantiPoint.Packages.Core
             configureAction(options);
 
             services.AddTransient<ISearchService>(provider =>
-                GetServiceFromProviders<ISearchService>(provider)
-                ?? provider.GetRequiredService<DatabaseSearchService>());
+            {
+                var localSearch = GetServiceFromProviders<ISearchService>(provider)
+                    ?? provider.GetRequiredService<DatabaseSearchService>();
+                var searchOptions = provider.GetRequiredService<IOptions<SearchOptions>>();
+                if (!searchOptions.Value.EnableUpstreamSearch)
+                {
+                    return localSearch;
+                }
+
+                return new FederatedSearchService(
+                    localSearch,
+                    provider.GetRequiredService<IMirrorService>(),
+                    searchOptions,
+                    provider.GetRequiredService<Microsoft.Extensions.Logging.ILogger<FederatedSearchService>>());
+            });
             services.AddTransient<ISearchIndexer>(provider =>
                 GetServiceFromProviders<ISearchIndexer>(provider)
                 ?? provider.GetRequiredService<NullSearchIndexer>());

--- a/src/AvantiPoint.Packages.Core/Mirror/IMirrorService.cs
+++ b/src/AvantiPoint.Packages.Core/Mirror/IMirrorService.cs
@@ -3,6 +3,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using AvantiPoint.Packages.Protocol.Models;
 using NuGet.Versioning;
 
 namespace AvantiPoint.Packages.Core
@@ -12,6 +13,15 @@ namespace AvantiPoint.Packages.Core
     /// </summary>
     public interface IMirrorService
     {
+        /// <summary>
+        /// Searches every enabled upstream NuGet source. Individual source failures are omitted;
+        /// cancellation of the complete operation is propagated to the caller.
+        /// </summary>
+        Task<IReadOnlyList<SearchResponse>> SearchAsync(
+            SearchRequest request,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<IReadOnlyList<SearchResponse>>([]);
+
         /// <summary>
         /// Attempt to find a package's versions using mirroring. This will merge
         /// results from the configured upstream source with the locally indexed packages.

--- a/src/AvantiPoint.Packages.Core/Mirror/MirrorService.cs
+++ b/src/AvantiPoint.Packages.Core/Mirror/MirrorService.cs
@@ -26,6 +26,7 @@ namespace AvantiPoint.Packages.Core
         private readonly ILocalPackageCacheService _localPackageCache;
         private readonly ILogger<MirrorService> _logger;
         private readonly ISecretProtector _secretProtector;
+        private readonly IPackageSourceSearchClient _packageSourceSearchClient;
 
         public MirrorService(
             IPackageService localPackages,
@@ -35,6 +36,27 @@ namespace AvantiPoint.Packages.Core
             ILocalPackageCacheService localPackageCache,
             ILogger<MirrorService> logger,
             ISecretProtector secretProtector)
+            : this(
+                localPackages,
+                packageSourceService,
+                indexer,
+                storage,
+                localPackageCache,
+                logger,
+                secretProtector,
+                new PackageSourceSearchClient(secretProtector))
+        {
+        }
+
+        internal MirrorService(
+            IPackageService localPackages,
+            IPackageSourceService packageSourceService,
+            IPackageIndexingService indexer,
+            IPackageStorageService storage,
+            ILocalPackageCacheService localPackageCache,
+            ILogger<MirrorService> logger,
+            ISecretProtector secretProtector,
+            IPackageSourceSearchClient packageSourceSearchClient)
         {
             _secretProtector = secretProtector ?? throw new ArgumentNullException(nameof(secretProtector));
             _localPackages = localPackages ?? throw new ArgumentNullException(nameof(localPackages));
@@ -43,6 +65,43 @@ namespace AvantiPoint.Packages.Core
             _storage = storage ?? throw new ArgumentNullException(nameof(storage));
             _localPackageCache = localPackageCache ?? throw new ArgumentNullException(nameof(localPackageCache));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _packageSourceSearchClient = packageSourceSearchClient
+                ?? throw new ArgumentNullException(nameof(packageSourceSearchClient));
+        }
+
+        public async Task<IReadOnlyList<SearchResponse>> SearchAsync(
+            SearchRequest request,
+            CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(request);
+
+            var sources = await _packageSourceService.GetEnabledUpstreamSourcesAsync(cancellationToken);
+            var searches = sources.Select(source => SearchSourceAsync(source, request, cancellationToken));
+            var responses = await Task.WhenAll(searches);
+            return responses.OfType<SearchResponse>().ToList();
+        }
+
+        private async Task<SearchResponse?> SearchSourceAsync(
+            PackageSource source,
+            SearchRequest request,
+            CancellationToken cancellationToken)
+        {
+            try
+            {
+                return await _packageSourceSearchClient.SearchAsync(source, request, cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception exception)
+            {
+                _logger.LogWarning(
+                    exception,
+                    "Unable to search upstream package source {SourceName}",
+                    source.Name);
+                return null;
+            }
         }
 
         public async Task<IReadOnlyList<NuGetVersion>?> FindPackageVersionsOrNullAsync(

--- a/src/AvantiPoint.Packages.Core/PackageSources/IPackageSourceSearchClient.cs
+++ b/src/AvantiPoint.Packages.Core/PackageSources/IPackageSourceSearchClient.cs
@@ -1,0 +1,13 @@
+using System.Threading;
+using System.Threading.Tasks;
+using AvantiPoint.Packages.Protocol.Models;
+
+namespace AvantiPoint.Packages.Core;
+
+internal interface IPackageSourceSearchClient
+{
+    Task<SearchResponse> SearchAsync(
+        PackageSource source,
+        SearchRequest request,
+        CancellationToken cancellationToken);
+}

--- a/src/AvantiPoint.Packages.Core/PackageSources/PackageSourceSearchClient.cs
+++ b/src/AvantiPoint.Packages.Core/PackageSources/PackageSourceSearchClient.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AvantiPoint.Packages.Protocol;
+using AvantiPoint.Packages.Protocol.Models;
+
+namespace AvantiPoint.Packages.Core;
+
+internal sealed class PackageSourceSearchClient(ISecretProtector secretProtector) : IPackageSourceSearchClient
+{
+    public async Task<SearchResponse> SearchAsync(
+        PackageSource source,
+        SearchRequest request,
+        CancellationToken cancellationToken)
+    {
+        using var httpClient = PackageSourceHttpClientFactory.Create(
+            source,
+            Timeout.InfiniteTimeSpan,
+            secretProtector);
+        var client = new NuGetClientFactory(httpClient, source.FeedUrl).CreateSearchClient();
+
+        return await client.SearchAsync(
+            request.Query,
+            request.Skip,
+            request.Take,
+            request.IncludePrerelease,
+            request.IncludeSemVer2,
+            request.PackageType,
+            request.Framework,
+            cancellationToken);
+    }
+}

--- a/src/AvantiPoint.Packages.Core/Search/FederatedSearchService.cs
+++ b/src/AvantiPoint.Packages.Core/Search/FederatedSearchService.cs
@@ -1,0 +1,192 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using AvantiPoint.Packages.Protocol.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NuGet.Versioning;
+
+namespace AvantiPoint.Packages.Core;
+
+/// <summary>
+/// Decorates the configured local search provider with live searches across enabled upstream
+/// NuGet sources. Only package search is federated; autocomplete, versions, and dependents retain
+/// the configured local provider's behavior.
+/// </summary>
+public sealed class FederatedSearchService(
+    ISearchService localSearch,
+    IMirrorService mirror,
+    IOptions<SearchOptions> options,
+    ILogger<FederatedSearchService> logger) : ISearchService
+{
+    private readonly SearchOptions _options = options.Value;
+
+    public async Task<SearchResponse> SearchAsync(
+        SearchRequest request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var windowRequest = CreateWindowRequest(request);
+        var local = await localSearch.SearchAsync(windowRequest, cancellationToken);
+
+        IReadOnlyList<SearchResponse> upstream;
+        using var timeout = new CancellationTokenSource(_options.UpstreamSearchTimeout);
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(
+            cancellationToken,
+            timeout.Token);
+
+        try
+        {
+            upstream = await mirror.SearchAsync(windowRequest, linked.Token);
+        }
+        catch (OperationCanceledException) when (
+            !cancellationToken.IsCancellationRequested && timeout.IsCancellationRequested)
+        {
+            logger.LogWarning(
+                "Upstream package search exceeded the configured timeout of {Timeout}; returning local results",
+                _options.UpstreamSearchTimeout);
+            upstream = [];
+        }
+        catch (Exception exception) when (!cancellationToken.IsCancellationRequested)
+        {
+            logger.LogWarning(
+                exception,
+                "Upstream package search failed; returning local results");
+            upstream = [];
+        }
+
+        return Merge(local, upstream, request, _options.MergeStrategy);
+    }
+
+    public Task<AutocompleteResponse> AutocompleteAsync(
+        AutocompleteRequest request,
+        CancellationToken cancellationToken) =>
+        localSearch.AutocompleteAsync(request, cancellationToken);
+
+    public Task<AutocompleteResponse> ListPackageVersionsAsync(
+        VersionsRequest request,
+        CancellationToken cancellationToken) =>
+        localSearch.ListPackageVersionsAsync(request, cancellationToken);
+
+    public Task<DependentsResponse> FindDependentsAsync(
+        string packageId,
+        CancellationToken cancellationToken) =>
+        localSearch.FindDependentsAsync(packageId, cancellationToken);
+
+    private static SearchRequest CreateWindowRequest(SearchRequest request)
+    {
+        var requestedEnd = Math.Min(
+            (long)Math.Max(0, request.Skip) + Math.Max(0, request.Take),
+            int.MaxValue);
+
+        return new SearchRequest
+        {
+            Skip = 0,
+            Take = (int)requestedEnd,
+            IncludePrerelease = request.IncludePrerelease,
+            IncludeSemVer2 = request.IncludeSemVer2,
+            PackageType = request.PackageType,
+            Framework = request.Framework,
+            Query = request.Query,
+        };
+    }
+
+    private static SearchResponse Merge(
+        SearchResponse local,
+        IReadOnlyList<SearchResponse> upstream,
+        SearchRequest originalRequest,
+        FederatedSearchMergeStrategy strategy)
+    {
+        var responses = new[] { local }.Concat(upstream).ToList();
+        var candidates = responses
+            .SelectMany(response => response.Data ?? [])
+            .OfType<SearchResult>()
+            .ToList();
+        var merged = strategy switch
+        {
+            FederatedSearchMergeStrategy.Union => candidates,
+            FederatedSearchMergeStrategy.Deduplicate => Deduplicate(candidates, preferFirst: false),
+            FederatedSearchMergeStrategy.LocalPreferred => Deduplicate(candidates, preferFirst: true),
+            _ => throw new ArgumentOutOfRangeException(nameof(strategy), strategy, "Unknown merge strategy."),
+        };
+        var page = merged
+            .Skip(Math.Max(0, originalRequest.Skip))
+            .Take(Math.Max(0, originalRequest.Take))
+            .ToList();
+        var totalHits = SumTotalHits(responses);
+        if (strategy != FederatedSearchMergeStrategy.Union)
+        {
+            totalHits = Math.Max(merged.Count, totalHits - (candidates.Count - merged.Count));
+        }
+
+        return new SearchResponse
+        {
+            Context = local.Context
+                ?? upstream.Select(response => response.Context).FirstOrDefault(context => context is not null),
+            TotalHits = totalHits,
+            Data = page,
+        };
+    }
+
+    private static List<SearchResult> Deduplicate(
+        IReadOnlyList<SearchResult> candidates,
+        bool preferFirst)
+    {
+        var merged = new List<SearchResult>(candidates.Count);
+        var indexes = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var candidate in candidates)
+        {
+            if (string.IsNullOrWhiteSpace(candidate.PackageId)
+                || !indexes.TryGetValue(candidate.PackageId, out var index))
+            {
+                if (!string.IsNullOrWhiteSpace(candidate.PackageId))
+                {
+                    indexes[candidate.PackageId] = merged.Count;
+                }
+
+                merged.Add(candidate);
+                continue;
+            }
+
+            if (!preferFirst && IsNewer(candidate, merged[index]))
+            {
+                merged[index] = candidate;
+            }
+        }
+
+        return merged;
+    }
+
+    private static bool IsNewer(SearchResult candidate, SearchResult current)
+    {
+        var candidateValid = NuGetVersion.TryParse(candidate.Version, out var candidateVersion);
+        var currentValid = NuGetVersion.TryParse(current.Version, out var currentVersion);
+
+        if (candidateValid && currentValid)
+        {
+            return candidateVersion > currentVersion;
+        }
+
+        return candidateValid && !currentValid;
+    }
+
+    private static long SumTotalHits(IEnumerable<SearchResponse> responses)
+    {
+        long total = 0;
+        foreach (var response in responses)
+        {
+            if (response.TotalHits > long.MaxValue - total)
+            {
+                return long.MaxValue;
+            }
+
+            total += Math.Max(0, response.TotalHits);
+        }
+
+        return total;
+    }
+}

--- a/src/AvantiPoint.Packages.Core/Validation/ValidateSearchOptions.cs
+++ b/src/AvantiPoint.Packages.Core/Validation/ValidateSearchOptions.cs
@@ -6,6 +6,9 @@ namespace AvantiPoint.Packages.Core;
 
 public class ValidateSearchOptions : IValidateOptions<SearchOptions>
 {
+    private static readonly TimeSpan MaximumCancellationTimeout =
+        TimeSpan.FromMilliseconds(uint.MaxValue - 1L);
+
     private static readonly HashSet<string> AllowedTypes = new(StringComparer.OrdinalIgnoreCase)
     {
         "Database",
@@ -36,6 +39,19 @@ public class ValidateSearchOptions : IValidateOptions<SearchOptions>
         if (options.ReconcileBatchSize < 1)
         {
             return ValidateOptionsResult.Fail("Search:ReconcileBatchSize must be at least 1.");
+        }
+
+        if (options.UpstreamSearchTimeout <= TimeSpan.Zero
+            || options.UpstreamSearchTimeout > MaximumCancellationTimeout)
+        {
+            return ValidateOptionsResult.Fail(
+                $"Search:UpstreamSearchTimeout must be greater than zero and no more than {MaximumCancellationTimeout}.");
+        }
+
+        if (!Enum.IsDefined(options.MergeStrategy))
+        {
+            return ValidateOptionsResult.Fail(
+                $"Search:MergeStrategy '{options.MergeStrategy}' is not supported.");
         }
 
         return ValidateOptionsResult.Success;

--- a/src/AvantiPoint.Packages.Protocol/Search/SearchClient.cs
+++ b/src/AvantiPoint.Packages.Protocol/Search/SearchClient.cs
@@ -30,7 +30,15 @@ namespace AvantiPoint.Packages.Protocol
                 // See: https://github.com/loic-sharma/BaGet/issues/314
                 var client = await _clientfactory.GetSearchClientAsync(cancellationToken);
 
-                return await client.SearchAsync(query, skip, take, includePrerelease, includeSemVer2, packageType, framework);
+                return await client.SearchAsync(
+                    query,
+                    skip,
+                    take,
+                    includePrerelease,
+                    includeSemVer2,
+                    packageType,
+                    framework,
+                    cancellationToken);
             }
         }
     }

--- a/tests/AvantiPoint.Packages.Integration.Tests/FederatedSearchIntegrationTests.cs
+++ b/tests/AvantiPoint.Packages.Integration.Tests/FederatedSearchIntegrationTests.cs
@@ -1,0 +1,45 @@
+using System.Net.Http.Json;
+using AvantiPoint.Packages.Core;
+using AvantiPoint.Packages.Integration.Tests.TestInfrastructure;
+using AvantiPoint.Packages.Protocol.Models;
+
+namespace AvantiPoint.Packages.Integration.Tests;
+
+public sealed class FederatedSearchIntegrationTests
+{
+    [Fact]
+    public async Task Search_FindsUpstreamPackageWithoutMirroringItLocally()
+    {
+        var packageId = $"Federated.Search.{Guid.NewGuid():N}";
+        await using var upstream = await UpstreamOpenFeedHost.StartAsync(
+            cancellationToken: TestContext.Current.CancellationToken);
+        await upstream.SeedPackageAsync(
+            packageId,
+            "1.0.0",
+            TestContext.Current.CancellationToken);
+        await using var feed = await FeedUnderTestHost.StartAsync(
+            new FeedUnderTestOptions
+            {
+                UpstreamServiceIndexUrl = upstream.ServiceIndexUrl,
+                CachingStrategy = PackageSourceCachingStrategy.ProxyOnly,
+                IncludeMirroredPackages = false,
+                EnableUpstreamSearch = true,
+                MergeStrategy = FederatedSearchMergeStrategy.LocalPreferred,
+            },
+            TestContext.Current.CancellationToken);
+
+        var response = await feed.Client.GetFromJsonAsync<SearchResponse>(
+            $"/v3/search?q={Uri.EscapeDataString(packageId)}&take=20&semVerLevel=2.0.0",
+            TestContext.Current.CancellationToken);
+
+        Assert.NotNull(response);
+        Assert.Contains(
+            response.Data,
+            result => string.Equals(result.PackageId, packageId, StringComparison.OrdinalIgnoreCase));
+        Assert.Null(await feed.FindPackageAsync(
+            packageId,
+            "1.0.0",
+            TestContext.Current.CancellationToken));
+        Assert.Equal(0, FeedUnderTestHost.CountPackageFiles(feed.StoragePath));
+    }
+}

--- a/tests/AvantiPoint.Packages.Integration.Tests/TestInfrastructure/FeedUnderTestHost.cs
+++ b/tests/AvantiPoint.Packages.Integration.Tests/TestInfrastructure/FeedUnderTestHost.cs
@@ -83,6 +83,9 @@ public sealed class FeedUnderTestHost : IAsyncDisposable
             ["Database:Type"] = "Sqlite",
             ["Search:Type"] = "Database",
             ["Search:IncludeMirroredPackages"] = options.IncludeMirroredPackages ? "true" : "false",
+            ["Search:EnableUpstreamSearch"] = options.EnableUpstreamSearch ? "true" : "false",
+            ["Search:UpstreamSearchTimeout"] = options.UpstreamSearchTimeout.ToString("c"),
+            ["Search:MergeStrategy"] = options.MergeStrategy.ToString(),
             ["Storage:Type"] = "FileSystem",
             ["Storage:Path"] = packagesPath,
             ["ConnectionStrings:Sqlite"] = $"Data Source={dbPath}",
@@ -202,6 +205,13 @@ public sealed class FeedUnderTestOptions
     public string ApiKey { get; init; } = TestPackageBuilder.DefaultApiKey;
 
     public bool IncludeMirroredPackages { get; init; } = true;
+
+    public bool EnableUpstreamSearch { get; init; }
+
+    public TimeSpan UpstreamSearchTimeout { get; init; } = TimeSpan.FromSeconds(2);
+
+    public FederatedSearchMergeStrategy MergeStrategy { get; init; } =
+        FederatedSearchMergeStrategy.LocalPreferred;
 
     public string? UpstreamServiceIndexUrl { get; init; }
 

--- a/tests/AvantiPoint.Packages.Search.Tests/ValidateSearchOptionsTests.cs
+++ b/tests/AvantiPoint.Packages.Search.Tests/ValidateSearchOptionsTests.cs
@@ -25,4 +25,34 @@ public class ValidateSearchOptionsTests
         var result = _validator.Validate(Options.DefaultName, new SearchOptions { Type = "Solr" });
         Assert.True(result.Failed);
     }
+
+    [Fact]
+    public void NonPositiveUpstreamTimeout_Fails()
+    {
+        var result = _validator.Validate(
+            Options.DefaultName,
+            new SearchOptions { UpstreamSearchTimeout = TimeSpan.Zero });
+
+        Assert.True(result.Failed);
+    }
+
+    [Fact]
+    public void UnsupportedUpstreamTimeout_Fails()
+    {
+        var result = _validator.Validate(
+            Options.DefaultName,
+            new SearchOptions { UpstreamSearchTimeout = TimeSpan.FromDays(50) });
+
+        Assert.True(result.Failed);
+    }
+
+    [Fact]
+    public void UnknownMergeStrategy_Fails()
+    {
+        var result = _validator.Validate(
+            Options.DefaultName,
+            new SearchOptions { MergeStrategy = (FederatedSearchMergeStrategy)int.MaxValue });
+
+        Assert.True(result.Failed);
+    }
 }

--- a/tests/AvantiPoint.Packages.Tests/Mirror/MirrorServiceTests.cs
+++ b/tests/AvantiPoint.Packages.Tests/Mirror/MirrorServiceTests.cs
@@ -2,6 +2,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using AvantiPoint.Packages.Core;
+using AvantiPoint.Packages.Protocol.Models;
 using Microsoft.Extensions.Logging;
 using Moq;
 using NuGet.Versioning;
@@ -10,6 +11,47 @@ namespace AvantiPoint.Packages.Tests.Mirror;
 
 public class MirrorServiceTests
 {
+    [Fact]
+    public async Task SearchAsync_ReturnsSuccessfulSourcesWhenAnotherSourceFails()
+    {
+        var successful = new PackageSource { Name = "successful", Priority = 1 };
+        var failing = new PackageSource { Name = "failing", Priority = 2 };
+        var packageSources = new Mock<IPackageSourceService>();
+        packageSources
+            .Setup(service => service.GetEnabledUpstreamSourcesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([successful, failing]);
+        var upstream = new StubPackageSourceSearchClient((source, _, _) =>
+        {
+            if (source == failing)
+            {
+                throw new HttpRequestException("unavailable");
+            }
+
+            return Task.FromResult(new SearchResponse
+            {
+                TotalHits = 1,
+                Data = [new SearchResult { PackageId = "Example", Version = "1.0.0" }],
+            });
+        });
+        var service = new MirrorService(
+            Mock.Of<IPackageService>(),
+            packageSources.Object,
+            Mock.Of<IPackageIndexingService>(),
+            Mock.Of<IPackageStorageService>(),
+            Mock.Of<ILocalPackageCacheService>(),
+            Mock.Of<ILogger<MirrorService>>(),
+            new NullSecretProtector(),
+            upstream);
+
+        var results = await service.SearchAsync(
+            new SearchRequest { Query = "Example", Take = 20 },
+            TestContext.Current.CancellationToken);
+
+        var result = Assert.Single(results);
+        Assert.Equal("Example", Assert.Single(result.Data).PackageId);
+        Assert.Equal(2, upstream.SearchCount);
+    }
+
     [Fact]
     public async Task MirrorAsync_WhenPackageInStorage_ReturnsAlreadyAvailableWithoutIndexing()
     {
@@ -183,5 +225,23 @@ public class MirrorServiceTests
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
         return packages.Object;
+    }
+
+    private sealed class StubPackageSourceSearchClient(
+        Func<PackageSource, SearchRequest, CancellationToken, Task<SearchResponse>> search)
+        : IPackageSourceSearchClient
+    {
+        private int _searchCount;
+
+        public int SearchCount => _searchCount;
+
+        public Task<SearchResponse> SearchAsync(
+            PackageSource source,
+            SearchRequest request,
+            CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref _searchCount);
+            return search(source, request, cancellationToken);
+        }
     }
 }

--- a/tests/AvantiPoint.Packages.Tests/Search/FederatedSearchServiceTests.cs
+++ b/tests/AvantiPoint.Packages.Tests/Search/FederatedSearchServiceTests.cs
@@ -1,0 +1,205 @@
+using AvantiPoint.Packages.Core;
+using AvantiPoint.Packages.Protocol.Models;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace AvantiPoint.Packages.Tests.Search;
+
+public sealed class FederatedSearchServiceTests
+{
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(true, true)]
+    public void DependencyInjection_OnlyDecoratesSearchWhenEnabled(
+        bool enabled,
+        bool expectFederated)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Search:Type"] = "Database",
+                ["Search:EnableUpstreamSearch"] = enabled.ToString(),
+            })
+            .Build();
+        var local = new Mock<ISearchService>();
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(configuration);
+        services.AddSingleton(Mock.Of<IHostEnvironment>(environment =>
+            environment.EnvironmentName == Environments.Development));
+        services.AddLogging();
+        services.AddSingleton(Mock.Of<IMirrorService>());
+        services.AddNuGetApiApplication(options =>
+            options.Services.AddProvider<ISearchService>((_, _) => local.Object));
+        using var provider = services.BuildServiceProvider();
+
+        var search = provider.GetRequiredService<ISearchService>();
+
+        if (expectFederated)
+        {
+            Assert.IsType<FederatedSearchService>(search);
+        }
+        else
+        {
+            Assert.Same(local.Object, search);
+        }
+    }
+
+    [Theory]
+    [InlineData(FederatedSearchMergeStrategy.LocalPreferred, "1.0.0", 3)]
+    [InlineData(FederatedSearchMergeStrategy.Deduplicate, "2.0.0", 3)]
+    [InlineData(FederatedSearchMergeStrategy.Union, "1.0.0", 4)]
+    public async Task SearchAsync_MergesResultsUsingConfiguredStrategy(
+        FederatedSearchMergeStrategy strategy,
+        string expectedDuplicateVersion,
+        int expectedTotalHits)
+    {
+        SearchRequest? localRequest = null;
+        SearchRequest? upstreamRequest = null;
+        var local = new Mock<ISearchService>();
+        local
+            .Setup(service => service.SearchAsync(It.IsAny<SearchRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<SearchRequest, CancellationToken>((request, _) => localRequest = request)
+            .ReturnsAsync(Response(
+                Result("Duplicate", "1.0.0"),
+                Result("Local", "1.0.0")));
+        var mirror = new Mock<IMirrorService>();
+        mirror
+            .Setup(service => service.SearchAsync(It.IsAny<SearchRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<SearchRequest, CancellationToken>((request, _) => upstreamRequest = request)
+            .ReturnsAsync([
+                Response(
+                    Result("Duplicate", "2.0.0"),
+                    Result("Upstream", "1.0.0")),
+            ]);
+        var service = CreateService(local.Object, mirror.Object, strategy);
+
+        var response = await service.SearchAsync(
+            new SearchRequest { Query = "package", Skip = 0, Take = 20 },
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(expectedTotalHits, response.TotalHits);
+        Assert.Equal(expectedTotalHits, response.Data.Count);
+        Assert.Equal(
+            expectedDuplicateVersion,
+            response.Data.First(result => result.PackageId == "Duplicate").Version);
+        Assert.NotNull(localRequest);
+        Assert.NotNull(upstreamRequest);
+        Assert.Equal(20, localRequest.Take);
+        Assert.Equal(20, upstreamRequest.Take);
+    }
+
+    [Fact]
+    public async Task SearchAsync_AppliesPaginationAfterMerging()
+    {
+        var local = SearchServiceReturning(Response(
+            Result("First", "1.0.0"),
+            Result("Second", "1.0.0")));
+        var mirror = new Mock<IMirrorService>();
+        mirror
+            .Setup(service => service.SearchAsync(It.IsAny<SearchRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([Response(Result("Third", "1.0.0"))]);
+        var service = CreateService(local.Object, mirror.Object, FederatedSearchMergeStrategy.LocalPreferred);
+
+        var response = await service.SearchAsync(
+            new SearchRequest { Skip = 1, Take = 1 },
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal("Second", Assert.Single(response.Data).PackageId);
+        local.Verify(service => service.SearchAsync(
+            It.Is<SearchRequest>(request => request.Skip == 0 && request.Take == 2),
+            It.IsAny<CancellationToken>()));
+        mirror.Verify(service => service.SearchAsync(
+            It.Is<SearchRequest>(request => request.Skip == 0 && request.Take == 2),
+            It.IsAny<CancellationToken>()));
+    }
+
+    [Fact]
+    public async Task SearchAsync_WhenUpstreamTimesOut_ReturnsLocalResults()
+    {
+        var local = SearchServiceReturning(Response(Result("Local", "1.0.0")));
+        var mirror = new Mock<IMirrorService>();
+        mirror
+            .Setup(service => service.SearchAsync(It.IsAny<SearchRequest>(), It.IsAny<CancellationToken>()))
+            .Returns<SearchRequest, CancellationToken>(async (_, cancellationToken) =>
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                return [];
+            });
+        var service = CreateService(
+            local.Object,
+            mirror.Object,
+            FederatedSearchMergeStrategy.LocalPreferred,
+            TimeSpan.FromMilliseconds(25));
+
+        var response = await service.SearchAsync(
+            new SearchRequest { Take = 20 },
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal("Local", Assert.Single(response.Data).PackageId);
+        Assert.Equal(1, response.TotalHits);
+    }
+
+    [Fact]
+    public async Task SearchAsync_WhenUpstreamFails_ReturnsLocalResults()
+    {
+        var local = SearchServiceReturning(Response(Result("Local", "1.0.0")));
+        var mirror = new Mock<IMirrorService>();
+        mirror
+            .Setup(service => service.SearchAsync(It.IsAny<SearchRequest>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("unavailable"));
+        var service = CreateService(
+            local.Object,
+            mirror.Object,
+            FederatedSearchMergeStrategy.LocalPreferred);
+
+        var response = await service.SearchAsync(
+            new SearchRequest { Take = 20 },
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal("Local", Assert.Single(response.Data).PackageId);
+        Assert.Equal(1, response.TotalHits);
+    }
+
+    private static FederatedSearchService CreateService(
+        ISearchService local,
+        IMirrorService mirror,
+        FederatedSearchMergeStrategy strategy,
+        TimeSpan? timeout = null) =>
+        new(
+            local,
+            mirror,
+            Options.Create(new SearchOptions
+            {
+                EnableUpstreamSearch = true,
+                MergeStrategy = strategy,
+                UpstreamSearchTimeout = timeout ?? TimeSpan.FromSeconds(1),
+            }),
+            NullLogger<FederatedSearchService>.Instance);
+
+    private static Mock<ISearchService> SearchServiceReturning(SearchResponse response)
+    {
+        var service = new Mock<ISearchService>();
+        service
+            .Setup(search => search.SearchAsync(It.IsAny<SearchRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(response);
+        return service;
+    }
+
+    private static SearchResponse Response(params SearchResult[] results) => new()
+    {
+        Context = new SearchContext(),
+        TotalHits = results.Length,
+        Data = results,
+    };
+
+    private static SearchResult Result(string id, string version) => new()
+    {
+        PackageId = id,
+        Version = version,
+        Versions = [],
+    };
+}


### PR DESCRIPTION
## Summary
- add opt-in live NuGet search across enabled upstream package sources
- support LocalPreferred, Deduplicate, and Union merge strategies with post-merge pagination
- return local results when upstream searches fail or exceed the configured timeout
- preserve custom mirror implementations and existing local search behavior by default
- document configuration and demonstrate lightweight proxy-only federation

## Validation
- dotnet test --solution APPackages.slnx -c Release --report-github (490 total, 455 passed, 35 skipped, 0 failed)
- Docusaurus production build
- two-host HTTP integration test verifies upstream discovery without local mirroring

Closes #585