### PR TITLE
Run release builds on Linux

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       contents: read
     with:
       name: Build Release Packages
-      runs-on: windows-latest
+      runs-on: ubuntu-latest
       solution-path: APPackages.slnx
       dotnet-version: 10.0.x
       code-sign: true


### PR DESCRIPTION
## Summary

Change the release build runner from `windows-latest` to `ubuntu-latest`.

Nothing else changes. The existing signing configuration, signing credentials, signed `NuGet` artifact, certificate extraction, and protected NuGet.org publish job remain exactly as they were.

## Root cause

The release build was running the test suite against a Windows-container Docker daemon, while the integration tests require Linux container images.

## Validation

- the PR diff is exactly one line
- Linux restore and package build passed in the branch validation run
- full Linux test suite passed: 486 succeeded, 4 skipped, 0 failed
- `git diff --check` passes

Signing was deliberately not changed.