### PR TITLE
Fix signed release test selection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,9 @@ jobs:
       contents: read
     with:
       name: Build Release Packages
-      runs-on: ubuntu-latest
+      # The Sign CLI used by code-sign requires Windows. Docker-backed tests run in the
+      # Ubuntu Build Package Feed workflow, so this signed build runs the remaining tests.
+      runs-on: windows-latest
       solution-path: APPackages.slnx
       dotnet-version: 10.0.x
       code-sign: true
@@ -22,6 +24,12 @@ jobs:
       codeSignCertificateProfile: ${{ vars.CODESIGN_CERTIFICATEPROFILE }}
       use-microsoft-testing-platform: true
       dotnet-test-report-github: true
+      test-projects: |
+        tests/AvantiPoint.Packages.Host.Admin.Tests/AvantiPoint.Packages.Host.Admin.Tests.csproj
+        tests/AvantiPoint.Packages.Protocol.Tests/AvantiPoint.Packages.Protocol.Tests.csproj
+        tests/AvantiPoint.Packages.Registry.Npm.Tests/AvantiPoint.Packages.Registry.Npm.Tests.csproj
+        tests/AvantiPoint.Packages.Tests/AvantiPoint.Packages.Tests.csproj
+        tests/AvantiPoint.Packages.UI.Tests/AvantiPoint.Packages.UI.Tests.csproj
       artifact-name: NuGet
     secrets:
       codeSignClientId: ${{ secrets.CodeSignClientId }}


### PR DESCRIPTION
## Summary

- restore the signed release build to `windows-latest`, matching AvantiPoint.Aspire
- use the reusable workflow's `test-projects` allow-list to run the five Windows-safe test assemblies
- leave all existing signing inputs, credentials, artifact handling, certificate extraction, and protected NuGet.org publishing unchanged
- continue relying on the Ubuntu `Build Package Feed` workflow for the complete Docker-backed test suite

## Root cause

The release pipeline has two incompatible platform requirements in one reusable build job:

1. the Docker-backed integration tests require Linux containers
2. the existing `sign` CLI requires Windows and fails on Ubuntu with `System.DllNotFoundException: kernel32.dll`

AvantiPoint.Aspire solves the same constraint by keeping its signed build on Windows and explicitly allow-listing non-integration test projects. This change applies that pattern here. The main CI workflow remains the authoritative full Linux test run.

## Validation

PR validation run: https://github.com/AvantiPoint/avantipoint.packages/actions/runs/29693000081

- Windows restore and package build passed
- every allow-listed project passed: 318 succeeded, 4 skipped, 0 failed
- no Docker-backed project was scheduled
- the unchanged signing step started on Windows and reached Azure login without the previous `kernel32.dll` failure
- Azure then rejected only the PR branch subject with `AADSTS7002131`, as expected because the federated identity is scoped to `master`
- `git diff --check` passes

The prior master run demonstrates the Linux-side failure this replaces: https://github.com/AvantiPoint/avantipoint.packages/actions/runs/29660392606

Signing behavior is deliberately unchanged.